### PR TITLE
New command line parsing

### DIFF
--- a/csb/README.md
+++ b/csb/README.md
@@ -22,7 +22,7 @@ The execution of the application is split in two different phases:
 ### Running phase 1
 
 ```
-$SPARK_HOME/bin/spark-submit csb-dep.jar gen_dist $DATA/dataset_01/conn.log $DATA/dataset_01/alert aug.log seed
+$SPARK_HOME/bin/spark-submit csb.jar seed -a $DATA/dataset_01/alert -b $DATA/dataset_01/conn.log
 ```
 
 The output will be:
@@ -34,7 +34,7 @@ The output will be:
 
 The phase 2 is composed of three separate steps:
 1. Synthetic graph generation, which is done using either one the algorithms listed below
-2. Properties generation, which can be skipped with the *--no-prop* parameter
+2. Properties generation, which can be skipped with the *-x* or the *--exclude-prop* options
 3. Graph saving using Spark serialization methods (Neo4j serialization is under development)
 4. Veracity computation of degree, in-degree, out-degree and PageRank metrics
 
@@ -43,7 +43,7 @@ The phase 2 is composed of three separate steps:
 The following will run the Barabási–Albert algorithm with 10 iterations:
 
 ```
-$SPARK_HOME/bin/spark-submit csb-dep.jar ba seed 10
+$SPARK_HOME/bin/spark-submit csb.jar synth ba -m all 10 0.2
 ```
 
 #### Kronecker
@@ -52,5 +52,5 @@ $SPARK_HOME/bin/spark-submit csb-dep.jar ba seed 10
 The following will run the stochastic Kronecker algorithm with 15 iterations using the *seed.mtx* matrix:
 
 ```
-$SPARK_HOME/bin/spark-submit csb-dep.jar kro $DATA/dataset_01/seed.mtx seed 15
+$SPARK_HOME/bin/spark-submit csb.jar synth kro -m all 15 $DATA/dataset_01/seed.mtx
 ```

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
@@ -2,7 +2,7 @@ package edu.msstate.dasi.csb
 
 import org.apache.log4j.{Level, Logger}
 
-import scopt.OptionParser
+//import scopt.OptionParser
 
 object Benchmark {
 
@@ -104,156 +104,180 @@ object Benchmark {
   def main(args: Array[String]) {
 
 
-    val dP = Params()
-    val h = ParamsHelp()
+//    val dP = Params()
+//    val h = ParamsHelp()
+//
+//    val parser = new OptionParser[Params]("Benchmark") {
+//      head(s"Benchmark $versionString: a synthetic Graph Generator for the busy scientist.")
+//
+//      /**
+//        * All Arguments:
+//        */
+//      opt[String]("output")
+//        .text(s"${h.outputGraphPrefix_desc} Default ${dP.outputGraphPrefix}")
+//        .action((x, c) => c.copy(outputGraphPrefix = x))
+//      opt[Int]("partitions")
+//        .text(s"${h.partitions_desc} Default: ${dP.partitions}")
+//        .validate(x => if (x > 0) success else failure("Partition count must be greater than 0."))
+//        .action((x, c) => c.copy(partitions = x))
+//      opt[String]("backend")
+//        .text(s"${h.backend_desc} Default: ${dP.backend}")
+//        .validate(x => if (x == "fs" || x == "neo4j") success else failure("Backend must be fs or neo4j."))
+//        .action((x, c) => c.copy(backend = x))
+//      opt[String]("checkpointDir")
+//        .text(s"${h.checkpointDir_desc} Default: ${dP.checkpointDir}")
+//        .action((x, c) => c.copy(checkpointDir = Some(x)))
+//      opt[Int]("checkpointInterval")
+//        .text(s"${h.checkpointInterval_desc} Default: ${dP.checkpointInterval}")
+//        .action((x, c) => c.copy(checkpointInterval = x))
+//      opt[Unit]("debug")
+//        .hidden()
+//        .action((_, c) => c.copy(debug = true))
+//        .text(s"Debug mode, prints all log output to terminal. default: ${dP.debug}")
+//
+//      /**
+//        * GenDist Arguments:
+//        */
+//      note("\n")
+//      cmd("gen_dist").action((_, c) => c.copy(mode = "gen_dist"))
+//        .text(s"Generate distribution data for a given input dataset.")
+//        .children(
+//          arg[String]("bro_log")
+//            .text(s"${h.connLog_desc} Default: ${dP.connLog}")
+//            .required()
+//            .action((x, c) => c.copy(connLog = x)),
+//          arg[String]("alert_log")
+//            .text(s"${h.alertLog_desc} Default: ${dP.alertLog}")
+//            .required()
+//            .action((x, c) => c.copy(alertLog = x)),
+//          arg[String]("aug_log")
+//            .text(s"${h.augLog_desc} Default: ${dP.augLog}")
+//            .required()
+//            .action((x, c) => c.copy(augLog = x)),
+//          arg[String]("seed")
+//            .text(s"${h.seed_desc} Default: ${dP.seed}")
+//            .required()
+//            .action((x, c) => c.copy(seed = x))
+//        )
+//
+//      /**
+//        * BA Arguments:
+//        */
+//      note("\n")
+//      cmd("ba").action((_, c) => c.copy(mode = "ba"))
+//        .text(s"Generate synthetic graph using the Barabasi–Albert model.")
+//        .children(
+//          opt[Unit]("no-prop")
+//            .text(s"${h.noProp_desc} default: ${dP.noProp}")
+//            .action((_, c) => c.copy(noProp = true)),
+//          opt[Double]("fraction-per-iter")
+//            .text(s"${h.fractionPerIter_desc} default: ${dP.fractionPerIter}")
+//            .action((x, c) => c.copy(fractionPerIter = x)),
+//          arg[String]("seed")
+//            .text(s"${h.seed_desc} default: ${dP.seed}")
+//            .required()
+//            .action((x, c) => c.copy(seed = x)),
+//          arg[Int]("<# of Iterations>")
+//            .text(s"${h.baIter_desc} default: ${dP.baIter}")
+//            .validate(x => if (x > 0) success else failure("Iteration count must be greater than 0."))
+//            .action((x, c) => c.copy(baIter = x))
+//        )
+//
+//      /**
+//        * Kronecker Arguments
+//        */
+//      note("\n")
+//      cmd("kro").action((_, c) => c.copy(mode = "kro"))
+//        .text(s"Generate synthetic graph using the Probabilistic Kronecker model.")
+//        .children(
+//          opt[Unit]("no-prop")
+//            .text(s"${h.noProp_desc} default ${dP.noProp}")
+//            .action((_, c) => c.copy(noProp = true)),
+//          arg[String]("seed-mtx")
+//            .text(s"${h.seedMtx_desc} default: ${dP.seedMtx}")
+//            .required()
+//            .action((x, c) => c.copy(seedMtx = x)),
+//          arg[String]("seed")
+//            .text(s"${h.seed_desc} default: ${dP.seed}")
+//            .required()
+//            .action((x, c) => c.copy(seed = x)),
+//          arg[Int]("<# of Iterations>")
+//            .text(s"${h.kroIter_desc} default: ${dP.kroIter}")
+//            .validate(x => if (x > 0) success else failure("Iteration count must be greater than 0."))
+//            .action((x, c) => c.copy(kroIter = x))
+//        )
+//
+//      /**
+//       * Veracity Arguments
+//       */
+//      note("\n")
+//      cmd("ver").action((_, c) => c.copy(mode = "ver"))
+//        .text(s"Compute veracity metrics on a given vertices and edge seed files")
+//        .children(
+//          arg[String]("seed")
+//              .text(s"${h.seed_Metric} default: ${dP.seed}")
+//              .required()
+//              .action((x,c) => c.copy(seed = x)),
+//          arg[String]("synth")
+//              .text(s"${h.synth_Metric}")
+//              .required()
+//              .action((x,c) => c.copy(synth = x)),
+//          arg[String]("metric")
+//            .text(s"${h.veracity_Desc}")
+//            .required()
+//            .action((x,c) => c.copy(metric = x)),
+//          arg[String]("save_file")
+//            .text(s"${h.veracity_File}")
+//            .required()
+//            .action((x,c) => c.copy(metricSave = x))
+//        )
+//
+//      /**
+//       * Workload Arguments
+//       */
+//      note("\n")
+//      cmd("workload").action((_, c) => c.copy(mode = "workload"))
+//        .text(s"Execute the workloads on an existing graph")
+//        .children(
+//          arg[String]("graph")
+//              .text(s"${h.graph} default: ${dP.graph}")
+//              .required()
+//              .action((x,c) => c.copy(graph = x))
+//        )
+//
+//    }
+//
+//    parser.parse(args, dP) match {
+//      case Some(params) => if (params.mode != "") run(params)
+//      else {
+//        println("Error: Must specify command")
+//        parser.showUsageAsError()
+//      }
+//      case _ => sys.exit(1)
+//    }
 
-    val parser = new OptionParser[Params]("Benchmark") {
-      head(s"Benchmark $versionString: a synthetic Graph Generator for the busy scientist.")
+    Logger.getLogger("org").setLevel(Level.OFF)
+    Logger.getLogger("akka").setLevel(Level.OFF)
 
-      /**
-        * All Arguments:
-        */
-      opt[String]("output")
-        .text(s"${h.outputGraphPrefix_desc} Default ${dP.outputGraphPrefix}")
-        .action((x, c) => c.copy(outputGraphPrefix = x))
-      opt[Int]("partitions")
-        .text(s"${h.partitions_desc} Default: ${dP.partitions}")
-        .validate(x => if (x > 0) success else failure("Partition count must be greater than 0."))
-        .action((x, c) => c.copy(partitions = x))
-      opt[String]("backend")
-        .text(s"${h.backend_desc} Default: ${dP.backend}")
-        .validate(x => if (x == "fs" || x == "neo4j") success else failure("Backend must be fs or neo4j."))
-        .action((x, c) => c.copy(backend = x))
-      opt[String]("checkpointDir")
-        .text(s"${h.checkpointDir_desc} Default: ${dP.checkpointDir}")
-        .action((x, c) => c.copy(checkpointDir = Some(x)))
-      opt[Int]("checkpointInterval")
-        .text(s"${h.checkpointInterval_desc} Default: ${dP.checkpointInterval}")
-        .action((x, c) => c.copy(checkpointInterval = x))
-      opt[Unit]("debug")
-        .hidden()
-        .action((_, c) => c.copy(debug = true))
-        .text(s"Debug mode, prints all log output to terminal. default: ${dP.debug}")
+    val parser = new OptionParser("csb", versionString, Config())
 
-      /**
-        * GenDist Arguments:
-        */
-      note("\n")
-      cmd("gen_dist").action((_, c) => c.copy(mode = "gen_dist"))
-        .text(s"Generate distribution data for a given input dataset.")
-        .children(
-          arg[String]("bro_log")
-            .text(s"${h.connLog_desc} Default: ${dP.connLog}")
-            .required()
-            .action((x, c) => c.copy(connLog = x)),
-          arg[String]("alert_log")
-            .text(s"${h.alertLog_desc} Default: ${dP.alertLog}")
-            .required()
-            .action((x, c) => c.copy(alertLog = x)),
-          arg[String]("aug_log")
-            .text(s"${h.augLog_desc} Default: ${dP.augLog}")
-            .required()
-            .action((x, c) => c.copy(augLog = x)),
-          arg[String]("seed")
-            .text(s"${h.seed_desc} Default: ${dP.seed}")
-            .required()
-            .action((x, c) => c.copy(seed = x))
-        )
+    parser.parse(args) match {
+      case Some(config) =>
+//        if ( ! params.debug ) {
+          //turn off annoying log messages
 
-      /**
-        * BA Arguments:
-        */
-      note("\n")
-      cmd("ba").action((_, c) => c.copy(mode = "ba"))
-        .text(s"Generate synthetic graph using the Barabasi–Albert model.")
-        .children(
-          opt[Unit]("no-prop")
-            .text(s"${h.noProp_desc} default: ${dP.noProp}")
-            .action((_, c) => c.copy(noProp = true)),
-          opt[Double]("fraction-per-iter")
-            .text(s"${h.fractionPerIter_desc} default: ${dP.fractionPerIter}")
-            .action((x, c) => c.copy(fractionPerIter = x)),
-          arg[String]("seed")
-            .text(s"${h.seed_desc} default: ${dP.seed}")
-            .required()
-            .action((x, c) => c.copy(seed = x)),
-          arg[Int]("<# of Iterations>")
-            .text(s"${h.baIter_desc} default: ${dP.baIter}")
-            .validate(x => if (x > 0) success else failure("Iteration count must be greater than 0."))
-            .action((x, c) => c.copy(baIter = x))
-        )
+//        } else {
+//
+//        }
 
-      /**
-        * Kronecker Arguments
-        */
-      note("\n")
-      cmd("kro").action((_, c) => c.copy(mode = "kro"))
-        .text(s"Generate synthetic graph using the Probabilistic Kronecker model.")
-        .children(
-          opt[Unit]("no-prop")
-            .text(s"${h.noProp_desc} default ${dP.noProp}")
-            .action((_, c) => c.copy(noProp = true)),
-          arg[String]("seed-mtx")
-            .text(s"${h.seedMtx_desc} default: ${dP.seedMtx}")
-            .required()
-            .action((x, c) => c.copy(seedMtx = x)),
-          arg[String]("seed")
-            .text(s"${h.seed_desc} default: ${dP.seed}")
-            .required()
-            .action((x, c) => c.copy(seed = x)),
-          arg[Int]("<# of Iterations>")
-            .text(s"${h.kroIter_desc} default: ${dP.kroIter}")
-            .validate(x => if (x > 0) success else failure("Iteration count must be greater than 0."))
-            .action((x, c) => c.copy(kroIter = x))
-        )
-
-      /**
-       * Veracity Arguments
-       */
-      note("\n")
-      cmd("ver").action((_, c) => c.copy(mode = "ver"))
-        .text(s"Compute veracity metrics on a given vertices and edge seed files")
-        .children(
-          arg[String]("seed")
-              .text(s"${h.seed_Metric} default: ${dP.seed}")
-              .required()
-              .action((x,c) => c.copy(seed = x)),
-          arg[String]("synth")
-              .text(s"${h.synth_Metric}")
-              .required()
-              .action((x,c) => c.copy(synth = x)),
-          arg[String]("metric")
-            .text(s"${h.veracity_Desc}")
-            .required()
-            .action((x,c) => c.copy(metric = x)),
-          arg[String]("save_file")
-            .text(s"${h.veracity_File}")
-            .required()
-            .action((x,c) => c.copy(metricSave = x))
-        )
-
-      /**
-       * Workload Arguments
-       */
-      note("\n")
-      cmd("workload").action((_, c) => c.copy(mode = "workload"))
-        .text(s"Execute the workloads on an existing graph")
-        .children(
-          arg[String]("graph")
-              .text(s"${h.graph} default: ${dP.graph}")
-              .required()
-              .action((x,c) => c.copy(graph = x))
-        )
-
-    }
-
-    parser.parse(args, dP) match {
-      case Some(params) => if (params.mode != "") run(params)
-      else {
-        println("Error: Must specify command")
-        parser.showUsageAsError()
-      }
-      case _ => sys.exit(1)
+        config.mode match {
+          case "seed" => println("seed")
+          case "synth" => println("synth")
+          case "veracity" => println("veracity")
+          case "workload" => println("workload")
+        }
+        println("part " + config.partitions)
+      case None => sys.exit(1)
     }
   }
 

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
@@ -3,312 +3,35 @@ package edu.msstate.dasi.csb
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.graphx.Graph
 
-//import scopt.OptionParser
-
 object Benchmark {
 
   val versionString = "0.2-DEV"
 
-//  case class ParamsHelp(
-//                         /**
-//                           * Any Arguments
-//                           */
-//                         outputGraphPrefix_desc: String = "Prefix to use when saving the output graph",
-//                         partitions_desc: String = "Number of partitions to set RDDs to.",
-//                         backend_desc: String = "Backend used to save generated data (fs or neo4j).",
-//                         checkpointDir_desc: String = "Directory for checkpointing intermediate results. Checkpointing helps with recovery and eliminates temporary shuffle files on disk.",
-//                         checkpointInterval_desc: String = "Iterations between each checkpoint. Only used if checkpointDir is set.",
-//                         seed_desc: String = "Path of the seed.",
-//
-//                         /**
-//                           * GenDist Arguments
-//                           */
-//                         connLog_desc: String = "Bro IDS conn.log file to augment with a SNORT alert.log.",
-//                         alertLog_desc: String = "SNORT alert augment with a Bro IDS conn.log.",
-//                         augLog_desc: String = "Augmented Bro IDS conn.log and SNORT alert.log.",
-//
-//                         /**
-//                           * BA Arguments
-//                           */
-//                         noProp_desc: String = "Specify whether to generate random properties during generation or not.",
-//                         fractionPerIter_desc: String = "The fraction of vertices to add to the graph per iteration.",
-//                         baIter_desc: String = "Number of iterations for Barabasi–Albert model.",
-//
-//                         /**
-//                           * Kronecker Arguments
-//                           */
-//                         seedMtx_desc: String = "Space-separated matrix file to use as a seed for Kronecker.",
-//                         kroIter_desc: String = "Number of iterations for Kronecker model.",
-//
-//                         /**
-//                           * veracity arguements
-//                           */
-//                         veracity_Desc: String = "The veracity metric you want to compute. Options include: degree, inDegree, outDegree, pageRank.",
-//                         veracity_File: String = "The file to save the metric information.",
-//                         seed_Metric: String = "Serialized file to use as a seed.",
-//                         synth_Metric: String = "Serialized file to use as a synth.",
-//
-//                         /**
-//                           * Workload Arguments
-//                           */
-//                         graph: String = "The input graph."
-//                       )
+  def main(args: Array[String]): Unit = {
 
-  case class Params(
-                     mode: String = "",
-
-                     /**
-                       * Any Arguments
-                       */
-                     outputGraphPrefix: String = "",
-                     partitions: Int = 120,
-                     backend: String = "fs",
-                     checkpointDir: Option[String] = None,
-                     checkpointInterval: Int = 10,
-                     debug: Boolean = false,
-
-                     /**
-                       * GenDist Arguments
-                       */
-                     connLog: String = "conn.log",
-                     alertLog: String = "alert",
-                     augLog: String = "aug.log",
-
-                     /**
-                       * BA Arguments
-                       */
-                     noProp: Boolean = false,
-                     fractionPerIter: Double = 0.1,
-                     seed: String = "seed",
-                     baIter: Long = 1000,
-
-                     /**
-                       * Kronecker Arguments
-                       */
-                     seedMtx: String = "seed.mtx",
-                     kroIter: Int = 10,
-
-                     /**
-                       * Veracity Arguments
-                       */
-                     metric: String = "hop-plot",
-                     metricSave: String = "hop-plotSave",
-                     synth: String = "synth",
-
-                     /**
-                       * Workload Arguments
-                       */
-                     graph: String = ""
-                   )
-
-
-  def main(args: Array[String]) {
-
-
-//    val dP = Params()
-//    val h = ParamsHelp()
-//
-//    val parser = new OptionParser[Params]("Benchmark") {
-//      head(s"Benchmark $versionString: a synthetic Graph Generator for the busy scientist.")
-//
-//      /**
-//        * All Arguments:
-//        */
-//      opt[String]("output")
-//        .text(s"${h.outputGraphPrefix_desc} Default ${dP.outputGraphPrefix}")
-//        .action((x, c) => c.copy(outputGraphPrefix = x))
-//      opt[Int]("partitions")
-//        .text(s"${h.partitions_desc} Default: ${dP.partitions}")
-//        .validate(x => if (x > 0) success else failure("Partition count must be greater than 0."))
-//        .action((x, c) => c.copy(partitions = x))
-//      opt[String]("backend")
-//        .text(s"${h.backend_desc} Default: ${dP.backend}")
-//        .validate(x => if (x == "fs" || x == "neo4j") success else failure("Backend must be fs or neo4j."))
-//        .action((x, c) => c.copy(backend = x))
-//      opt[String]("checkpointDir")
-//        .text(s"${h.checkpointDir_desc} Default: ${dP.checkpointDir}")
-//        .action((x, c) => c.copy(checkpointDir = Some(x)))
-//      opt[Int]("checkpointInterval")
-//        .text(s"${h.checkpointInterval_desc} Default: ${dP.checkpointInterval}")
-//        .action((x, c) => c.copy(checkpointInterval = x))
-//      opt[Unit]("debug")
-//        .hidden()
-//        .action((_, c) => c.copy(debug = true))
-//        .text(s"Debug mode, prints all log output to terminal. default: ${dP.debug}")
-//
-//      /**
-//        * GenDist Arguments:
-//        */
-//      note("\n")
-//      cmd("gen_dist").action((_, c) => c.copy(mode = "gen_dist"))
-//        .text(s"Generate distribution data for a given input dataset.")
-//        .children(
-//          arg[String]("bro_log")
-//            .text(s"${h.connLog_desc} Default: ${dP.connLog}")
-//            .required()
-//            .action((x, c) => c.copy(connLog = x)),
-//          arg[String]("alert_log")
-//            .text(s"${h.alertLog_desc} Default: ${dP.alertLog}")
-//            .required()
-//            .action((x, c) => c.copy(alertLog = x)),
-//          arg[String]("aug_log")
-//            .text(s"${h.augLog_desc} Default: ${dP.augLog}")
-//            .required()
-//            .action((x, c) => c.copy(augLog = x)),
-//          arg[String]("seed")
-//            .text(s"${h.seed_desc} Default: ${dP.seed}")
-//            .required()
-//            .action((x, c) => c.copy(seed = x))
-//        )
-//
-//      /**
-//        * BA Arguments:
-//        */
-//      note("\n")
-//      cmd("ba").action((_, c) => c.copy(mode = "ba"))
-//        .text(s"Generate synthetic graph using the Barabasi–Albert model.")
-//        .children(
-//          opt[Unit]("no-prop")
-//            .text(s"${h.noProp_desc} default: ${dP.noProp}")
-//            .action((_, c) => c.copy(noProp = true)),
-//          opt[Double]("fraction-per-iter")
-//            .text(s"${h.fractionPerIter_desc} default: ${dP.fractionPerIter}")
-//            .action((x, c) => c.copy(fractionPerIter = x)),
-//          arg[String]("seed")
-//            .text(s"${h.seed_desc} default: ${dP.seed}")
-//            .required()
-//            .action((x, c) => c.copy(seed = x)),
-//          arg[Int]("<# of Iterations>")
-//            .text(s"${h.baIter_desc} default: ${dP.baIter}")
-//            .validate(x => if (x > 0) success else failure("Iteration count must be greater than 0."))
-//            .action((x, c) => c.copy(baIter = x))
-//        )
-//
-//      /**
-//        * Kronecker Arguments
-//        */
-//      note("\n")
-//      cmd("kro").action((_, c) => c.copy(mode = "kro"))
-//        .text(s"Generate synthetic graph using the Probabilistic Kronecker model.")
-//        .children(
-//          opt[Unit]("no-prop")
-//            .text(s"${h.noProp_desc} default ${dP.noProp}")
-//            .action((_, c) => c.copy(noProp = true)),
-//          arg[String]("seed-mtx")
-//            .text(s"${h.seedMtx_desc} default: ${dP.seedMtx}")
-//            .required()
-//            .action((x, c) => c.copy(seedMtx = x)),
-//          arg[String]("seed")
-//            .text(s"${h.seed_desc} default: ${dP.seed}")
-//            .required()
-//            .action((x, c) => c.copy(seed = x)),
-//          arg[Int]("<# of Iterations>")
-//            .text(s"${h.kroIter_desc} default: ${dP.kroIter}")
-//            .validate(x => if (x > 0) success else failure("Iteration count must be greater than 0."))
-//            .action((x, c) => c.copy(kroIter = x))
-//        )
-//
-//      /**
-//       * Veracity Arguments
-//       */
-//      note("\n")
-//      cmd("ver").action((_, c) => c.copy(mode = "ver"))
-//        .text(s"Compute veracity metrics on a given vertices and edge seed files")
-//        .children(
-//          arg[String]("seed")
-//              .text(s"${h.seed_Metric} default: ${dP.seed}")
-//              .required()
-//              .action((x,c) => c.copy(seed = x)),
-//          arg[String]("synth")
-//              .text(s"${h.synth_Metric}")
-//              .required()
-//              .action((x,c) => c.copy(synth = x)),
-//          arg[String]("metric")
-//            .text(s"${h.veracity_Desc}")
-//            .required()
-//            .action((x,c) => c.copy(metric = x)),
-//          arg[String]("save_file")
-//            .text(s"${h.veracity_File}")
-//            .required()
-//            .action((x,c) => c.copy(metricSave = x))
-//        )
-//
-//      /**
-//       * Workload Arguments
-//       */
-//      note("\n")
-//      cmd("workload").action((_, c) => c.copy(mode = "workload"))
-//        .text(s"Execute the workloads on an existing graph")
-//        .children(
-//          arg[String]("graph")
-//              .text(s"${h.graph} default: ${dP.graph}")
-//              .required()
-//              .action((x,c) => c.copy(graph = x))
-//        )
-//
-//    }
-//
-//    parser.parse(args, dP) match {
-//      case Some(config) => if (config.mode != "") run(config)
-//      else {
-//        println("Error: Must specify command")
-//        parser.showUsageAsError()
-//      }
-//      case _ => sys.exit(1)
-//    }
-
-    Logger.getLogger("org").setLevel(Level.OFF)
-    Logger.getLogger("akka").setLevel(Level.OFF)
+    Logger.getLogger("org").setLevel(Level.ERROR)
+    Logger.getLogger("akka").setLevel(Level.ERROR)
 
     val parser = new OptionParser("csb", versionString, Config())
 
     parser.parse(args) match {
       case Some(config) =>
-//        if ( ! config.debug ) {
-          //turn off annoying log messages
-
-//        } else {
-//
-//        }
+        if ( config.debug ) {
+          Logger.getLogger("org").setLevel(Level.DEBUG)
+          Logger.getLogger("akka").setLevel(Level.DEBUG)
+        }
 
         config.mode match {
           case "seed" => run_gendist(config)
           case "synth" => run_synth(config)
           case "veracity" => run_veracity(config)
-          case "workload" => println("workload")
+          case "workload" => run_workload(config)
         }
       case None => sys.exit(1)
     }
   }
 
-  /** * Main function of our program, controls graph generation and other pieces.
-    *
-    * @param params Parameters for the function to run.
-    */
-  def run(params: Params): Boolean = {
-    if ( ! params.debug ) {
-      //turn off annoying log messages
-      Logger.getLogger("org").setLevel(Level.OFF)
-      Logger.getLogger("akka").setLevel(Level.OFF)
-    } else {
-
-    }
-
-    params.mode match {
-//      case "gen_dist" => run_gendist(config)
-//      case "ba" => run_synth(params)
-//      case "kro" => run_synth(params)
-//      case "ver" => run_ver(params)
-      case "workload" => run_workload(params)
-      case _ => sys.exit(1)
-    }
-
-    sys.exit()
-    true
-  }
-
-  def run_gendist(config: Config): Boolean = {
-    //these two statements create the aug log (conn.log plus alert)
+  private def run_gendist(config: Config): Boolean = {
     val logAug = new log_Augment()
     logAug.run(config.alertLog, config.connLog, config.outLog)
 
@@ -332,7 +55,7 @@ object Benchmark {
   }
 
   private def run_metrics(metrics: Seq[String], seed: Graph[VertexData, EdgeData], synth: Graph[VertexData, EdgeData]): Unit = {
-    if ( metrics.isEmpty || metrics.contains("none") ) return
+    if ( metrics.isEmpty ) return
 
     val all = metrics.contains("all")
 
@@ -351,13 +74,13 @@ object Benchmark {
       println(s"Out-Degree Veracity: $outDegVeracity")
     }
 
-    if ( all || metrics.contains("out-degree") ) {
+    if ( all || metrics.contains("pagerank") ) {
       val pageRankVeracity = Util.time("PageRank Veracity", PageRankVeracity(seed, synth))
       println(s"Page Rank Veracity: $pageRankVeracity")
     }
   }
 
-  def run_synth(config: Config): Boolean = {
+  private def run_synth(config: Config): Boolean = {
     var graphPs = null.asInstanceOf[GraphPersistence]
     config.backend match {
       case "fs" => graphPs = new SparkPersistence()
@@ -391,54 +114,91 @@ object Benchmark {
     true
   }
 
-  def run_veracity(config: Config): Boolean = {
+  private def run_veracity(config: Config): Boolean = {
     var graphPs = null.asInstanceOf[GraphPersistence]
     config.backend match {
       case "fs" => graphPs = new SparkPersistence()
       case "neo4j" => graphPs = new Neo4jPersistence()
     }
 
-    val seed = graphPs.loadGraph(config.seedGraphPrefix, config.partitions)
+    val seed = Util.time( "Load seed graph", graphPs.loadGraph(config.seedGraphPrefix, config.partitions) )
 
-    val synth = graphPs.loadGraph(config.synthGraphPrefix, config.partitions)
+    val synth = Util.time( "Load synth graph", graphPs.loadGraph(config.synthGraphPrefix, config.partitions) )
 
     run_metrics(config.metrics, seed, synth)
 
     true
   }
 
-  def run_workload(params: Params): Boolean = {
+  private def run_workload(config: Config): Boolean = {
     var graphPs = null.asInstanceOf[GraphPersistence]
-    params.backend match {
+    config.backend match {
       case "fs" => graphPs = new SparkPersistence()
       case "neo4j" => graphPs = new Neo4jPersistence()
     }
 
-    val graph = Util.time( "Load graph", graphPs.loadGraph(params.graph, params.partitions) )
+    val graph = Util.time( "Load graph", graphPs.loadGraph(config.graphPrefix, config.partitions) )
 
-    Util.time( "Count vertices", SparkWorkload.countVertices(graph) )
-    Util.time( "Count edges", SparkWorkload.countEdges(graph) )
+    var workload = null.asInstanceOf[Workload]
+    config.workloadBackend match {
+      case "spark" => workload = SparkWorkload
+      case "neo4j" => workload = Neo4jWorkload
+    }
 
-    Util.time( "Neighbors", SparkWorkload.neighbors(graph) )
-    Util.time( "In-neighbors", SparkWorkload.inNeighbors(graph) )
-    Util.time( "Out-neighbors", SparkWorkload.outNeighbors(graph) )
+    val workloads = config.workloads
 
-    Util.time( "In-edges", SparkWorkload.inEdges(graph) )
-    Util.time( "Out-edges", SparkWorkload.outEdges(graph) )
+    val all = workloads.contains("all")
 
-    Util.time( "Degree", SparkWorkload.degree(graph) )
-    Util.time( "In-degree", SparkWorkload.inDegree(graph) )
-    Util.time( "Out-degree", SparkWorkload.outDegree(graph) )
+    if ( all || workloads.contains("count-vertices") ) Util.time("Count vertices", workload.countVertices(graph))
+    if ( all || workloads.contains("count-edges") ) Util.time("Count edges", workload.countEdges(graph))
 
-    Util.time( "Connected Components", SparkWorkload.connectedComponents(graph) )
-    Util.time( "Strongly Connected Components", SparkWorkload.stronglyConnectedComponents(graph, 1) )
-    Util.time( "PageRank", SparkWorkload.pageRank(graph) )
-    Util.time( "Triangle Counting", SparkWorkload.triangleCount(graph) )
-    Util.time( "Betweenness Centrality", SparkWorkload.betweennessCentrality(graph, 10) )
-//    Util.time( "Closeness Centrality", SparkWorkload.closenessCentrality(vertex, graph) )
-//    Util.time( "Breadth-first Search", SparkWorkload.bfs(graph, src, dst) )
-//    Util.time( "Breadth-first Search", SparkWorkload.ssspSeq(graph, src, dst) )
-//    Util.time( "Breadth-first Search", SparkWorkload.ssspNum(graph, src, dst) )
+    if ( all || workloads.contains("degree") ) Util.time("Degree", workload.degree(graph))
+    if ( all || workloads.contains("in-degree") ) Util.time("In-degree", workload.inDegree(graph))
+    if ( all || workloads.contains("out-degree") ) Util.time("Out-degree", workload.outDegree(graph))
+
+    if ( all || workloads.contains("pagerank") ) {
+      Util.time("PageRank", workload.pageRank(graph))
+    }
+
+    if ( all || workloads.contains("bfs") ) {
+      Util.time("Breadth-first Search", workload.bfs(graph, config.srcVertex, config.dstVertex))
+    }
+
+    if ( all || workloads.contains("neighbors") ) Util.time("Neighbors", workload.neighbors(graph))
+    if ( all || workloads.contains("in-neighbors") ) Util.time("In-neighbors", workload.inNeighbors(graph))
+    if ( all || workloads.contains("out-neighbors") ) Util.time("Out-neighbors", workload.outNeighbors(graph))
+
+    if ( all || workloads.contains("in-edges") ) Util.time("Degree", workload.inEdges(graph))
+    if ( all || workloads.contains("out-edges") ) Util.time("In-degree", workload.outEdges(graph))
+
+    if ( all || workloads.contains("connected-components") ) {
+      Util.time("Connected Components", workload.connectedComponents(graph))
+    }
+
+    if ( all || workloads.contains("triangle-count") ) {
+      Util.time("Triangle Counting", workload.triangleCount(graph))
+    }
+
+    if ( all || workloads.contains("strongly-connected-components") ) {
+      Util.time("Strongly Connected Components", workload.stronglyConnectedComponents(graph, config.iterations))
+    }
+
+    if ( all || workloads.contains("betweenness-centrality") ) {
+      Util.time("Betweenness Centrality", workload.betweennessCentrality(graph, config.iterations))
+    }
+
+    if ( all || workloads.contains("closeness-centrality") ) {
+      Util.time("Closeness Centrality", workload.closenessCentrality(graph, config.srcVertex))
+    }
+
+    if ( all || workloads.contains("sssp") ) {
+      Util.time("Single Source Shortest Path", workload.sssp(graph, config.srcVertex))
+    }
+
+    if ( all || workloads.contains("subgraph-isomorphism") ) {
+      val pattern = Util.time("Load pattern", graphPs.loadGraph(config.patternPrefix, config.partitions))
+      Util.time("Subgraph Isomorphism", workload.subgraphIsomorphism(graph, pattern))
+    }
 
     true
   }

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
@@ -35,15 +35,15 @@ object Benchmark {
 
   private def run_gendist(config: Config): Boolean = {
     val logAug = new log_Augment()
-    logAug.run(config.alertLog, config.connLog, config.outLog)
+    logAug.run(config.alertLog, config.connLog, config.augLog)
 
     val seed = Util.time( "Log to graph", {
-      val seed = DataParser.logToGraph(config.outLog, config.partitions)
+      val seed = DataParser.logToGraph(config.augLog, config.partitions)
       println("Vertices #: " + seed.numVertices + ", Edges #: " + seed.numEdges)
       seed
     } )
 
-    Util.time( "Seed distributions", new DataDistributions(config.outLog) )
+    Util.time( "Seed distributions", new DataDistributions(config.augLog) )
 
     var graphPs = null.asInstanceOf[GraphPersistence]
     config.backend match {
@@ -95,7 +95,7 @@ object Benchmark {
       seed
     } )
 
-    val seedDists = new DataDistributions(config.outLog)
+    val seedDists = new DataDistributions(config.augLog)
 
     var synthesizer: GraphSynth = null
     config.synthesizer match {

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
@@ -46,7 +46,7 @@ object Benchmark {
     Util.time( "Seed distributions", new DataDistributions(config.augLog) )
 
     var graphPs = null.asInstanceOf[GraphPersistence]
-    config.backend match {
+    config.storageBackend match {
       case "fs" => graphPs = new SparkPersistence()
       case "neo4j" => graphPs = new Neo4jPersistence()
     }
@@ -84,7 +84,7 @@ object Benchmark {
 
   private def run_synth(config: Config): Boolean = {
     var graphPs = null.asInstanceOf[GraphPersistence]
-    config.backend match {
+    config.storageBackend match {
       case "fs" => graphPs = new SparkPersistence()
       case "neo4j" => graphPs = new Neo4jPersistence()
     }
@@ -107,7 +107,7 @@ object Benchmark {
 
     Util.time( "Save synth graph Object", graphPs.saveGraph(synth, config.synthGraphPrefix, overwrite = true))
 
-    if ( config.backend == "fs" ) {
+    if ( config.storageBackend == "fs" ) {
       Util.time("Save synth graph Text", graphPs.asInstanceOf[SparkPersistence].saveAsText(synth, config.synthGraphPrefix + "_text", overwrite = true))
     }
 
@@ -118,7 +118,7 @@ object Benchmark {
 
   private def run_veracity(config: Config): Boolean = {
     var graphPs = null.asInstanceOf[GraphPersistence]
-    config.backend match {
+    config.storageBackend match {
       case "fs" => graphPs = new SparkPersistence()
       case "neo4j" => graphPs = new Neo4jPersistence()
     }
@@ -134,7 +134,7 @@ object Benchmark {
 
   private def run_workload(config: Config): Boolean = {
     var graphPs = null.asInstanceOf[GraphPersistence]
-    config.backend match {
+    config.storageBackend match {
       case "fs" => graphPs = new SparkPersistence()
       case "neo4j" => graphPs = new Neo4jPersistence()
     }
@@ -144,7 +144,7 @@ object Benchmark {
     var workload = null.asInstanceOf[Workload]
     config.workloadBackend match {
       case "spark" => workload = SparkWorkload
-      case "neo4j" => workload = Neo4jWorkload
+      case "neo4j" => workload = new Neo4jWorkload(config.neo4jUrl, config.neo4jUsername, config.neo4jPassword)
     }
 
     val workloads = config.workloads

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
@@ -60,9 +60,8 @@ object Benchmark {
 
   private def run_metrics(metrics: Array[Veracity], seed: Graph[VertexData, EdgeData], synth: Graph[VertexData, EdgeData]): Unit = {
     for (metric <- metrics) {
-      val metricName = metric.getClass.getSimpleName.split("\\$").last
-      val veracity = Util.time(s"$metricName", metric(seed, synth))
-      println(s"$metricName: $veracity")
+      val veracity = Util.time(s"${metric.name} veracity", metric(seed, synth))
+      println(s"${metric.name} veracity: $veracity")
     }
   }
 

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Benchmark.scala
@@ -24,7 +24,7 @@ object Benchmark {
         }
 
         config.mode match {
-          case "seed" => run_gendist(config)
+          case "seed" => run_seed(config)
           case "synth" => run_synth(config)
           case "veracity" => run_veracity(config)
           case "workload" => run_workload(config)
@@ -33,7 +33,7 @@ object Benchmark {
     }
   }
 
-  private def run_gendist(config: Config): Boolean = {
+  private def run_seed(config: Config): Boolean = {
     val logAug = new log_Augment()
     logAug.run(config.alertLog, config.connLog, config.augLog)
 

--- a/csb/src/main/scala/edu/msstate/dasi/csb/ComponentFactory.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/ComponentFactory.scala
@@ -1,9 +1,12 @@
 package edu.msstate.dasi.csb
 
+/**
+ * Provides factory methods for each benchmark component, defining their behavior from an input configuration.
+ */
 class ComponentFactory(config: Config) {
 
   /**
-   *
+   * Returns the graph loader.
    */
   def getLoader: GraphPersistence = {
     config.graphLoader match {
@@ -13,7 +16,7 @@ class ComponentFactory(config: Config) {
   }
 
   /**
-   *
+   * Returns the graph saver.
    */
   def getSaver: GraphPersistence = {
     config.graphSaver match {
@@ -23,7 +26,7 @@ class ComponentFactory(config: Config) {
   }
 
   /**
-   *
+   * Returns the graph saver used for the text format.
    */
   def getTextSaver: Option[GraphPersistence] = {
     config.textSaver match {
@@ -34,7 +37,7 @@ class ComponentFactory(config: Config) {
   }
 
   /**
-   *
+   * Returns the synthesizer.
    */
   def getSynthesizer: GraphSynth = {
     config.synthesizer match {
@@ -44,7 +47,7 @@ class ComponentFactory(config: Config) {
   }
 
   /**
-   *
+   * Returns the workload engine.
    */
   def getWorkload: Workload = {
     config.workloadBackend match {

--- a/csb/src/main/scala/edu/msstate/dasi/csb/ComponentFactory.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/ComponentFactory.scala
@@ -1,0 +1,55 @@
+package edu.msstate.dasi.csb
+
+class ComponentFactory(config: Config) {
+
+  /**
+   *
+   */
+  def getLoader: GraphPersistence = {
+    config.graphLoader match {
+      case "spark" => SparkPersistence
+      case "neo4j" => Neo4jPersistence
+    }
+  }
+
+  /**
+   *
+   */
+  def getSaver: GraphPersistence = {
+    config.graphSaver match {
+      case "spark" => SparkPersistence
+      case "neo4j" => Neo4jPersistence
+    }
+  }
+
+  /**
+   *
+   */
+  def getTextSaver: Option[GraphPersistence] = {
+    config.textSaver match {
+      case "spark" => Some(SparkPersistence)
+      case "neo4j" => Some(Neo4jPersistence)
+      case "none" => None
+    }
+  }
+
+  /**
+   *
+   */
+  def getSynthesizer: GraphSynth = {
+    config.synthesizer match {
+      case "ba" => new ParallelBaSynth(config.partitions, config.iterations, config.sampleFraction)
+      case "kro" => new KroSynth(config.partitions, config.seedMatrix, config.iterations)
+    }
+  }
+
+  /**
+   *
+   */
+  def getWorkload: Workload = {
+    config.workloadBackend match {
+      case "spark" => SparkWorkload
+      case "neo4j" => new Neo4jWorkload(config.neo4jUrl, config.neo4jUsername, config.neo4jPassword)
+    }
+  }
+}

--- a/csb/src/main/scala/edu/msstate/dasi/csb/ComponentFactory.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/ComponentFactory.scala
@@ -46,10 +46,26 @@ class ComponentFactory(config: Config) {
     }
   }
 
+
+  def getMetrics: Array[Veracity] = {
+    var metrics = Array.empty[Veracity]
+
+    if (config.metrics.isEmpty) return metrics
+
+    val all = config.metrics.contains("all")
+
+    if (all || config.metrics.contains("degree")) metrics :+= DegreeVeracity
+    if (all || config.metrics.contains("in-degree")) metrics :+= InDegreeVeracity
+    if (all || config.metrics.contains("out-degree")) metrics :+= OutDegreeVeracity
+    if (all || config.metrics.contains("pagerank")) metrics :+= PageRankVeracity
+
+    metrics
+  }
+
   /**
    * Returns the workload engine.
    */
-  def getWorkload: Workload = {
+  def getWorkloadEngine: Workload = {
     config.workloadBackend match {
       case "spark" => SparkWorkload
       case "neo4j" => new Neo4jWorkload(config.neo4jUrl, config.neo4jUsername, config.neo4jPassword)

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -6,10 +6,12 @@ case class Config(
                  debug: Boolean = false,
                  mode: String = "",
                  partitions: Int = sc.defaultParallelism,
-                 storageBackend: String = "fs",
 
                  seedGraphPrefix: String = "seed",
                  synthGraphPrefix: String = "synth",
+                 graphLoader: String = "spark",
+                 graphSaver: String = "spark",
+                 textSaver: String = "none",
                  iterations: Int = 0,
 
                  alertLog: String = "alert",

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -9,6 +9,5 @@ case class Config(
 
                  alertLog: String = "alert",
                  connLog: String = "conn.log",
-                 augLog: String = "aug.log",
-                 seedPrefix: String = "seed"
+                 outLog: String = "out.log"
                  )

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -14,7 +14,7 @@ case class Config(
 
                  alertLog: String = "alert",
                  connLog: String = "conn.log",
-                 outLog: String = "out.log",
+                 augLog: String = "out.log",
 
                  synthesizer: String = "",
                  skipProperties: Boolean = false,

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -6,7 +6,7 @@ case class Config(
                  debug: Boolean = false,
                  mode: String = "",
                  partitions: Int = sc.defaultParallelism,
-                 backend: String = "fs",
+                 storageBackend: String = "fs",
 
                  seedGraphPrefix: String = "seed",
                  synthGraphPrefix: String = "synth",
@@ -27,6 +27,11 @@ case class Config(
 
                  workloads: Seq[String] = Seq("all"),
                  workloadBackend: String = "spark",
+
+                 neo4jUrl: String = "bolt://localhost",
+                 neo4jUsername: String = "neo4j",
+                 neo4jPassword: String = "neo4j",
+
                  graphPrefix: String = "graph",
                  srcVertex: VertexId = 0L,
                  dstVertex: VertexId = 0L,

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -1,12 +1,16 @@
 package edu.msstate.dasi.csb
 
+import org.apache.spark.graphx.VertexId
+
 case class Config(
+                 debug: Boolean = false,
                  mode: String = "",
                  partitions: Int = sc.defaultParallelism,
                  backend: String = "fs",
 
                  seedGraphPrefix: String = "seed",
                  synthGraphPrefix: String = "synth",
+                 iterations: Int = 0,
 
                  alertLog: String = "alert",
                  connLog: String = "conn.log",
@@ -14,11 +18,17 @@ case class Config(
 
                  synthesizer: String = "",
                  skipProperties: Boolean = false,
-                 iterations: Int = 0,
 
                  sampleFraction: Double = 0.1,
 
                  seedMatrix: String = "seed.mtx",
 
-                 metrics: Seq[String] = Seq("all")
+                 metrics: Seq[String] = Seq("all"),
+
+                 workloads: Seq[String] = Seq("all"),
+                 workloadBackend: String = "spark",
+                 graphPrefix: String = "graph",
+                 srcVertex: VertexId = 0L,
+                 dstVertex: VertexId = 0L,
+                 patternPrefix: String = "pattern"
                  )

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -14,7 +14,7 @@ case class Config(
 
                  alertLog: String = "alert",
                  connLog: String = "conn.log",
-                 augLog: String = "out.log",
+                 augLog: String = "aug.log",
 
                  synthesizer: String = "",
                  skipProperties: Boolean = false,

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -1,0 +1,14 @@
+package edu.msstate.dasi.csb
+
+case class Config(
+                 mode: String = "",
+                 partitions: Int = sc.defaultParallelism,
+
+                 inGraphPrefix: String = "",
+                 outGraphPrefix: String = "",
+
+                 alertLog: String = "alert",
+                 connLog: String = "conn.log",
+                 augLog: String = "aug.log",
+                 seedPrefix: String = "seed"
+                 )

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Config.scala
@@ -3,11 +3,22 @@ package edu.msstate.dasi.csb
 case class Config(
                  mode: String = "",
                  partitions: Int = sc.defaultParallelism,
+                 backend: String = "fs",
 
-                 inGraphPrefix: String = "",
-                 outGraphPrefix: String = "",
+                 seedGraphPrefix: String = "seed",
+                 synthGraphPrefix: String = "synth",
 
                  alertLog: String = "alert",
                  connLog: String = "conn.log",
-                 outLog: String = "out.log"
+                 outLog: String = "out.log",
+
+                 synthesizer: String = "",
+                 skipProperties: Boolean = false,
+                 iterations: Int = 0,
+
+                 sampleFraction: Double = 0.1,
+
+                 seedMatrix: String = "seed.mtx",
+
+                 metrics: Seq[String] = Seq("all")
                  )

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Neo4jPersistence.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Neo4jPersistence.scala
@@ -5,7 +5,7 @@ import java.io.{File, PrintWriter}
 import org.apache.hadoop.fs.FileUtil
 import org.apache.spark.graphx.Graph
 
-class Neo4jPersistence extends GraphPersistence {
+object Neo4jPersistence extends GraphPersistence {
   private val vertices_suffix = "_nodes"
   private val edges_suffix = "_relationships"
 

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Neo4jWorkload.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Neo4jWorkload.scala
@@ -3,17 +3,16 @@ package edu.msstate.dasi.csb
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.graphx.{Edge, Graph, VertexId}
-import org.apache.spark.rdd.RDD
 import org.neo4j.driver.v1.summary.ResultSummary
 import org.neo4j.driver.v1.{AccessMode, AuthTokens, GraphDatabase}
 
 import scala.reflect.ClassTag
 
-object Neo4jWorkload extends Workload {
+class Neo4jWorkload(url: String, username: String, password: String) extends Workload {
   /**
    * The Neo4j driver instance responsible for obtaining new sessions.
    */
-  private val driver = GraphDatabase.driver("bolt://localhost", AuthTokens.basic("neo4j", "password"))
+  private val driver = GraphDatabase.driver(url, AuthTokens.basic(username, password))
 
   /**
    *

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -47,7 +47,7 @@ class OptionParser(override val programName: String, programVersion: String, con
 
       opt[String]('l', "log")
         .valueName("<path>")
-        .text(s"Output path of the resulting augmented log [default: ${config.outLog}].")
+        .text(s"Output path of the resulting augmented log [default: ${config.augLog}].")
         .action((x, c) => c.copy(connLog = x)),
 
       opt[String]('o', "out-graph")

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -54,6 +54,11 @@ class OptionParser(override val programName: String, programVersion: String, con
         .text(s"Output path of the resulting augmented log [default: ${config.augLog}].")
         .action((x, c) => c.copy(augLog = x)),
 
+      opt[String]('w', "saver")
+        .valueName("<value>")
+        .text(s"Graph saver. Supported: spark|neo4j [default: ${config.graphSaver}].")
+        .action((x, c) => c.copy(graphSaver = x)),
+
       opt[String]('o', "out-graph")
         .valueName("<path>")
         .text(s"Output path prefix of the generated seed graph [default: ${config.seedGraphPrefix}].")
@@ -71,6 +76,11 @@ class OptionParser(override val programName: String, programVersion: String, con
     .text("Synthesizes a graph starting from a seed graph and the probability distributions of its properties.")
     .action( (_, c) => c.copy(mode = "synth", metrics = Seq()) )
     .children(
+      opt[String]('r', "loader")
+        .valueName("<value>")
+        .text(s"Graph loader. Supported: spark|neo4j [default: ${config.graphLoader}].")
+        .action((x, c) => c.copy(graphLoader = x)),
+
       opt[String]('s', "seed-graph")
         .valueName("<path>")
         .text(s"Path prefix of the seed graph [default: ${config.seedGraphPrefix}].")
@@ -82,6 +92,11 @@ class OptionParser(override val programName: String, programVersion: String, con
         .validate(path => if ( new File(path).isFile ) success else failure(s"$path is not a regular file") )
         .action((x, c) => c.copy(augLog = x)),
 
+      opt[String]('w', "saver")
+        .valueName("<value>")
+        .text(s"Graph saver. Supported: spark|neo4j [default: ${config.graphSaver}].")
+        .action((x, c) => c.copy(graphSaver = x)),
+
       opt[String]('o', "out-graph")
         .valueName("<path>")
         .text(s"Output path prefix of the generated synthetic graph [default: ${config.synthGraphPrefix}].")
@@ -92,7 +107,7 @@ class OptionParser(override val programName: String, programVersion: String, con
         .text(s"Save the generated synthetic graph in a text format. Supported: spark|neo4j [default: ${config.textSaver}].")
         .action((x, c) => c.copy(textSaver = x)),
 
-      opt[Unit]('x', "exclude-prop")
+      opt[Unit]('x', "exclude-properties")
         .text(s"Skip the properties generation [default: ${config.skipProperties}].")
         .action((_, c) => c.copy(skipProperties = true)),
 
@@ -146,6 +161,11 @@ class OptionParser(override val programName: String, programVersion: String, con
     .text("Executes one or more veracity metrics. Available metrics: degree|in-degree|out-degree|pagerank|all")
     .action( (_, c) => c.copy(mode = "veracity") )
     .children(
+      opt[String]('r', "loader")
+        .valueName("<value>")
+        .text(s"Graph loader. Supported: spark|neo4j [default: ${config.graphLoader}].")
+        .action((x, c) => c.copy(graphLoader = x)),
+
       arg[Seq[String]]("<metric1,metric2,...>")
         .text(s"Comma separated list of veracity metrics to execute [default: ${config.metrics.mkString(",")}].")
         .action( (x, c) => c.copy(metrics = x) ),
@@ -208,6 +228,11 @@ class OptionParser(override val programName: String, programVersion: String, con
           s"Required by: bfs [default: random].")
         .validate(value => if (value > 0) success else failure("destination must be greater than 0"))
         .action( (x, c) => c.copy(dstVertex = x) ),
+
+      opt[String]('r', "loader")
+        .valueName("<value>")
+        .text(s"Graph loader. Supported: spark|neo4j [default: ${config.graphLoader}].")
+        .action((x, c) => c.copy(graphLoader = x)),
 
       opt[String]('t', "pattern")
         .valueName("<path>")

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -3,8 +3,6 @@ package edu.msstate.dasi.csb
 import java.io.File
 
 class OptionParser(override val programName: String, programVersion: String, config: Config) extends scopt.OptionParser[Config](programName) {
-  private val seedOutGraphPrefix = "seed"
-
   /**
    * Provides a wrapper method for the inheriting parse() method, avoiding the caller to specify again the default
    * Config instance.
@@ -12,7 +10,7 @@ class OptionParser(override val programName: String, programVersion: String, con
   def parse(args: Seq[String]): Option[Config] = super.parse(args, config)
 
   /*********************************************************************************************************************
-   * Begin of the ordered sequence of builder methods ******************************************************************
+   * Begin of the ordered builder methods ******************************************************************************
    ********************************************************************************************************************/
 
   head(s"$programName version $programVersion")
@@ -21,7 +19,7 @@ class OptionParser(override val programName: String, programVersion: String, con
 
   opt[Int]('p', "partitions")
     .valueName("<num>")
-    .text(s"Number of RDD partitions [default (level of parallelism detected on this system): ${config.partitions}].")
+    .text(s"Number of RDD partitions [default level of parallelism detected on this system: ${config.partitions}].")
     .validate(value => if (value > 0) success else failure("partitions must be greater than 0"))
     .action((x, c) => c.copy(partitions = x))
 
@@ -29,51 +27,120 @@ class OptionParser(override val programName: String, programVersion: String, con
 
   cmd("seed")
     .text("")
-    .action( (_, c) => c.copy(mode = "seed", outGraphPrefix = seedOutGraphPrefix) )
+    .action( (_, c) => c.copy(mode = "seed") )
     .children(
-      opt[String]("alert-log").abbr("al")
+      opt[String]('a', "alert-log")
         .valueName("<path>")
         .text(s"Path of the Snort connection log [default: ${config.alertLog}].")
         .validate(path => if ( new File(path).isFile ) success else failure(s"$path is not a regular file") )
         .action((x, c) => c.copy(alertLog = x)),
 
-      opt[String]("bro-log").abbr("bl")
+      opt[String]('b', "bro-log")
         .valueName("<path>")
         .text(s"Path of the Bro connection log [default: ${config.connLog}].")
         .validate(path => if ( new File(path).isFile ) success else failure(s"$path is not a regular file") )
         .action((x, c) => c.copy(connLog = x)),
 
-      opt[String]("out-log").abbr("ol")
+      opt[String]('l', "log")
         .valueName("<path>")
         .text(s"Output path of the resulting augmented log [default: ${config.outLog}].")
         .action((x, c) => c.copy(connLog = x)),
 
-      opt[String]("seed-graph").abbr("sg")
-        .text(s"Output path prefix to save the generated seed graph [default: $seedOutGraphPrefix].")
-        .action((x, c) => c.copy(outGraphPrefix = x))
+      opt[String]('o', "out-graph")
+        .valueName("<path>")
+        .text(s"Output path prefix of the generated seed graph [default: ${config.seedGraphPrefix}].")
+        .action((x, c) => c.copy(seedGraphPrefix = x))
     )
 
   note("")
 
   cmd("synth")
-    .action( (_, c) => c.copy(mode = "synth") )
     .text("")
+    .action( (_, c) => c.copy(mode = "synth", metrics = Seq()) )
+    .children(
+      opt[String]('s', "seed-graph")
+        .valueName("<path>")
+        .text(s"Path prefix of the seed graph [default: ${config.seedGraphPrefix}].")
+        .action((x, c) => c.copy(seedGraphPrefix = x)),
+
+      opt[String]('o', "out-graph")
+        .valueName("<path>")
+        .text(s"Output path prefix of the generated synthetic graph [default: ${config.synthGraphPrefix}].")
+        .action((x, c) => c.copy(synthGraphPrefix = x)),
+
+      opt[Unit]('x', "exclude-prop")
+        .text(s"Skip the properties generation [default: ${config.skipProperties}].")
+        .action((_, c) => c.copy(skipProperties = true)),
+
+      opt[Seq[String]]('m', "metrics")
+        .valueName("<list>")
+        .text(s"Comma separated list of veracity metrics to execute. Available: degree|in-degree|out-degree|pageRank|all [default: none].")
+        .action( (x, c) => c.copy(metrics = x) ),
+
+      note(""),
+
+      cmd("ba")
+        .text("")
+        .action( (_, c) => c.copy(synthesizer = "ba") )
+        .children(
+          arg[Int]("iterations")
+            .text(s"Number of algorithm's iterations.")
+            .action((x, c) => c.copy(iterations = x)),
+
+          arg[Double]("fraction")
+            .optional()
+            .text(s"Fraction of the data extracted at each iteration [default: ${config.sampleFraction}].")
+            .action((x, c) => c.copy(sampleFraction = x))
+        ),
+
+      note(""),
+
+      cmd("kro")
+        .text("")
+        .action( (_, c) => c.copy(synthesizer = "kro") )
+        .children(
+          arg[Int]("iterations")
+            .text(s"Number of algorithm's iterations.")
+            .action((x, c) => c.copy(iterations = x)),
+
+          arg[String]("matrix")
+            .optional()
+            .valueName("<path>")
+            .text(s"Path of the matrix file representing the starting seed [default: ${config.seedMatrix}].")
+            .action((x, c) => c.copy(seedMatrix = x))
+      )
+    )
 
   note("")
 
   cmd("veracity")
-    .action( (_, c) => c.copy(mode = "veracity") )
     .text("")
+    .action( (_, c) => c.copy(mode = "veracity") )
+    .children(
+      arg[Seq[String]]("metrics")
+        .text(s"Comma separated list of veracity metrics to execute. Available: degree|in-degree|out-degree|pageRank|all [default: ${config.metrics.mkString(",")}].")
+        .action( (x, c) => c.copy(metrics = x) ),
+
+      arg[String]("seed")
+        .optional()
+        .text(s"Path prefix of the seed graph [default: ${config.seedGraphPrefix}].")
+        .action((x, c) => c.copy(seedGraphPrefix = x)),
+
+      arg[String]("synth")
+        .optional()
+        .text(s"Path prefix of the seed graph [default: ${config.synthGraphPrefix}].")
+        .action((x, c) => c.copy(synthGraphPrefix = x))
+    )
 
   note("")
 
   cmd("workload")
-    .action( (_, c) => c.copy(mode = "workload") )
     .text("")
+    .action( (_, c) => c.copy(mode = "workload") )
 
   checkConfig( c => if (c.mode == "") failure("command cannot be empty") else success )
 
   /*********************************************************************************************************************
-   * End of the ordered sequence of builder methods ********************************************************************
+   * End of the ordered builder methods ********************************************************************************
    ********************************************************************************************************************/
 }

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -48,7 +48,7 @@ class OptionParser(override val programName: String, programVersion: String, con
       opt[String]('l', "log")
         .valueName("<path>")
         .text(s"Output path of the resulting augmented log [default: ${config.augLog}].")
-        .action((x, c) => c.copy(connLog = x)),
+        .action((x, c) => c.copy(augLog = x)),
 
       opt[String]('o', "out-graph")
         .valueName("<path>")
@@ -66,6 +66,12 @@ class OptionParser(override val programName: String, programVersion: String, con
         .valueName("<path>")
         .text(s"Path prefix of the seed graph [default: ${config.seedGraphPrefix}].")
         .action((x, c) => c.copy(seedGraphPrefix = x)),
+
+      opt[String]('l', "log")
+        .valueName("<path>")
+        .text(s"Path of the augmented log [default: ${config.augLog}].")
+        .validate(path => if ( new File(path).isFile ) success else failure(s"$path is not a regular file") )
+        .action((x, c) => c.copy(augLog = x)),
 
       opt[String]('o', "out-graph")
         .valueName("<path>")

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -9,6 +9,8 @@ class OptionParser(override val programName: String, programVersion: String, con
    */
   def parse(args: Seq[String]): Option[Config] = super.parse(args, config)
 
+  override def showUsageOnError = true
+
   /*********************************************************************************************************************
    * Begin of the ordered builder methods ******************************************************************************
    ********************************************************************************************************************/
@@ -16,6 +18,8 @@ class OptionParser(override val programName: String, programVersion: String, con
   head(s"$programName version $programVersion")
 
   version("version").hidden()
+
+  help("help").hidden()
 
   opt[Int]('p', "partitions")
     .valueName("<num>")

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -1,0 +1,66 @@
+package edu.msstate.dasi.csb
+
+import java.io.File
+
+class OptionParser(override val programName: String, programVersion: String, config: Config) extends scopt.OptionParser[Config](programName) {
+  head(s"$programName version $programVersion")
+
+  version("version").hidden()
+
+  opt[Int]('p', "partitions")
+    .valueName("<n>")
+    .text(s"The number of RDD partitions, default: the level of parallelism provided by Spark for this system [${config.partitions}]")
+    .validate(value => if (value > 0) success else failure("partitions must be greater than 0"))
+    .action((x, c) => c.copy(partitions = x))
+
+  note("")
+
+  cmd("seed")
+    .text("")
+    .action( (_, c) => c.copy(mode = "seed") )
+    .children(
+      arg[String]("bro_log")
+        .optional()
+        .text(s"The path of the Bro's connection log, default: ${config.connLog}")
+        .validate(path => if ( new File(path).isFile ) success else failure(s"$path is not a regular file") )
+        .action((x, c) => c.copy(connLog = x)),
+
+        arg[String]("alert_log")
+        .optional()
+        .text(s"The path of the Snort's connection log, default: ${config.alertLog}")
+        .validate(path => if ( new File(path).isFile ) success else failure(s"$path is not a regular file") )
+        .action((x, c) => c.copy(alertLog = x)),
+
+        arg[String]("aug_log")
+        .optional()
+        .text(s"The path where to save the resulting augmented log, default: ${config.augLog}")
+        .action((x, c) => c.copy(connLog = x)),
+
+        arg[String]("seed_graph")
+        .optional()
+        .text(s"The prefix used to save the generated seed graph, default: ${config.seedPrefix}")
+        .action((x, c) => c.copy(connLog = x))
+    )
+
+  note("")
+
+  cmd("synth")
+    .action( (_, c) => c.copy(mode = "synth") )
+    .text("")
+
+  note("")
+
+  cmd("veracity")
+    .action( (_, c) => c.copy(mode = "veracity") )
+    .text("")
+
+  note("")
+
+  cmd("workload")
+    .action( (_, c) => c.copy(mode = "workload") )
+    .text("")
+
+  checkConfig( c => if (c.mode == "") failure("command cannot be empty") else success )
+
+  def parse(args: Seq[String]): Option[Config] = super.parse(args, config)
+}

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -166,6 +166,18 @@ class OptionParser(override val programName: String, programVersion: String, con
         .validate(value => if (value == "spark" || value == "neo4j") success else failure("workload backend not supported"))
         .action( (x, c) => c.copy(workloadBackend = x) ),
 
+      opt[String]("neo4j-url")
+        .text(s"Neo4j connection URL [default: ${config.neo4jUrl}].")
+        .action( (x, c) => c.copy(neo4jUrl = x) ),
+
+      opt[String]("neo4j-username")
+        .text(s"Neo4j username [default: ${config.neo4jUsername}].")
+        .action( (x, c) => c.copy(neo4jUsername = x) ),
+
+      opt[String]("neo4j-password")
+        .text(s"Neo4j password [default: ${config.neo4jPassword}].")
+        .action( (x, c) => c.copy(neo4jPassword = x) ),
+
       opt[Int]('i', "iterations")
         .valueName("<num>")
         .text(s"Number of algorithm's iterations. " +

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -166,14 +166,14 @@ class OptionParser(override val programName: String, programVersion: String, con
       opt[Long]('s', "source")
         .valueName("<id>")
         .text(s"The source vertex ID. " +
-          s"Required by: bfs|closeness-centrality|sssp [default:].")
+          s"Required by: bfs|closeness-centrality|sssp [default: random].")
         .validate(value => if (value > 0) success else failure("source must be greater than 0"))
         .action( (x, c) => c.copy(srcVertex= x) ),
 
       opt[Long]('d', "destination")
         .valueName("<id>")
         .text(s"The destination vertex ID. " +
-          s"Required by: bfs [default:].")
+          s"Required by: bfs [default: random].")
         .validate(value => if (value > 0) success else failure("destination must be greater than 0"))
         .action( (x, c) => c.copy(dstVertex = x) ),
 
@@ -200,24 +200,6 @@ class OptionParser(override val programName: String, programVersion: String, con
     val iterationWorkloads = Seq("strongly-connected-components", "betweenness-centrality")
     if (c.workloads.intersect(iterationWorkloads).nonEmpty && c.iterations == 0) {
       failure("workload iterations not specified")
-    } else {
-      success
-    }
-  })
-
-  checkConfig( c => {
-    val srcWorkloads = Seq("bfs", "closeness-centrality", "sssp")
-    if (c.workloads.intersect(srcWorkloads).nonEmpty && c.srcVertex == 0) {
-      failure("source not specified")
-    } else {
-      success
-    }
-  })
-
-  checkConfig( c => {
-    val dstWorkloads = Seq("bfs")
-    if (c.workloads.intersect(dstWorkloads).nonEmpty && c.dstVertex == 0) {
-      failure("destination not specified")
     } else {
       success
     }

--- a/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/OptionParser.scala
@@ -57,7 +57,12 @@ class OptionParser(override val programName: String, programVersion: String, con
       opt[String]('o', "out-graph")
         .valueName("<path>")
         .text(s"Output path prefix of the generated seed graph [default: ${config.seedGraphPrefix}].")
-        .action((x, c) => c.copy(seedGraphPrefix = x))
+        .action((x, c) => c.copy(seedGraphPrefix = x)),
+
+        opt[String]('t', "as-text")
+        .valueName("<format>")
+        .text(s"Save the generated seed graph in a text format. Supported: spark|neo4j [default: ${config.textSaver}].")
+        .action((x, c) => c.copy(textSaver = x))
     )
 
   note("")
@@ -81,6 +86,11 @@ class OptionParser(override val programName: String, programVersion: String, con
         .valueName("<path>")
         .text(s"Output path prefix of the generated synthetic graph [default: ${config.synthGraphPrefix}].")
         .action((x, c) => c.copy(synthGraphPrefix = x)),
+
+      opt[String]('t', "as-text")
+        .valueName("<format>")
+        .text(s"Save the generated synthetic graph in a text format. Supported: spark|neo4j [default: ${config.textSaver}].")
+        .action((x, c) => c.copy(textSaver = x)),
 
       opt[Unit]('x', "exclude-prop")
         .text(s"Skip the properties generation [default: ${config.skipProperties}].")

--- a/csb/src/main/scala/edu/msstate/dasi/csb/PageRankVeracity.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/PageRankVeracity.scala
@@ -6,6 +6,8 @@ import org.apache.spark.mllib.rdd.RDDFunctions._
 import scala.reflect.ClassTag
 
 object PageRankVeracity extends Veracity {
+  val name: String = "PageRank"
+
   /**
    * Computes the pageRank veracity factor between two graphs.
    */

--- a/csb/src/main/scala/edu/msstate/dasi/csb/SparkPersistence.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/SparkPersistence.scala
@@ -6,7 +6,7 @@ import org.apache.hadoop.fs.FileUtil
 import org.apache.spark.graphx.{Edge, Graph, VertexId}
 import org.apache.spark.storage.StorageLevel
 
-class SparkPersistence extends GraphPersistence {
+object SparkPersistence extends GraphPersistence {
   private val vertices_suffix = "_vertices"
   private val edges_suffix = "_edges"
 

--- a/csb/src/main/scala/edu/msstate/dasi/csb/Veracity.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/Veracity.scala
@@ -6,6 +6,8 @@ import org.apache.spark.rdd.RDD
 import scala.reflect.ClassTag
 
 trait Veracity {
+  val name: String
+
   // TODO: we should find a more elegant solution for passing the bucket size to the inheriting class
   protected var globalBucketSize = 0.0
 

--- a/csb/src/main/scala/edu/msstate/dasi/csb/degreeVeracity.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/degreeVeracity.scala
@@ -36,6 +36,8 @@ sealed trait DegreeVeracity extends Veracity {
 }
 
 object DegreeVeracity extends DegreeVeracity {
+  val name: String = "Degree"
+
   /**
    * Computes the degree veracity factor between two graphs.
    */
@@ -45,6 +47,7 @@ object DegreeVeracity extends DegreeVeracity {
   }
 }
 object InDegreeVeracity extends DegreeVeracity {
+  val name: String = "In-degree"
   /**
    * Computes the in-degree veracity factor between two graphs.
    */
@@ -54,6 +57,8 @@ object InDegreeVeracity extends DegreeVeracity {
   }
 }
 object OutDegreeVeracity extends DegreeVeracity {
+  val name: String = "Out-degree"
+
   /**
    * Computes the out-degree veracity factor between two graphs.
    */

--- a/csb/src/main/scala/edu/msstate/dasi/csb/package.scala
+++ b/csb/src/main/scala/edu/msstate/dasi/csb/package.scala
@@ -9,9 +9,6 @@ import org.apache.spark.sql.SparkSession
 package object csb {
   private[csb] val sc = SparkSession.builder()
     .appName("Cyber Security Benchmark")
-    .config("spark.neo4j.bolt.url", "bolt://localhost")
-    .config("spark.neo4j.bolt.user", "neo4j")
-    .config("spark.neo4j.bolt.password", "password")
     .getOrCreate()
     .sparkContext
 }


### PR DESCRIPTION
Add new command line parsing feature which works as follow:

```
Usage: csb [seed|synth|veracity|workload] [options] <args>...

  -p, --partitions <num>   Number of RDD partitions [default detected level of parallelism: 8].

Command: seed [options]
Generates a property graph and the probability distributions of its properties starting from two log files.
  -a, --alert-log <path>   Path of the Snort connection log [default: alert].
  -b, --bro-log <path>     Path of the Bro connection log [default: conn.log].
  -l, --log <path>         Output path of the resulting augmented log [default: aug.log].
  -o, --out-graph <path>   Output path prefix of the generated seed graph [default: seed].

Command: synth [ba|kro] [options] <args>...
Synthesizes a graph starting from a seed graph and the probability distributions of its properties.
  -s, --seed-graph <path>  Path prefix of the seed graph [default: seed].
  -l, --log <path>         Path of the augmented log [default: aug.log].
  -o, --out-graph <path>   Output path prefix of the generated synthetic graph [default: synth].
  -x, --exclude-prop       Skip the properties generation [default: false].
  -m, --metrics <metric1,metric2,...>
                           Comma separated list of veracity metrics to execute. Available: degree|in-degree|out-degree|pagerank|all [default:].

Command: synth ba iterations [fraction]
Synthesizes the graph using the Barabási–Albert algorithm.
  iterations               Number of algorithm's iterations.
  fraction                 Fraction of the data extracted at each iteration [default: 0.1].

Command: synth kro iterations [matrix]
Synthesizes the graph using the Kronecker algorithm.
  iterations               Number of algorithm's iterations.
  matrix                   Path of the matrix file representing the starting seed [default: seed.mtx].

Command: veracity <metric1,metric2,...> [seed] [synth]
Executes one or more veracity metrics. Available metrics: degree|in-degree|out-degree|pagerank|all
  <metric1,metric2,...>    Comma separated list of veracity metrics to execute [default: all].
  seed                     Path prefix of the seed graph [default: seed].
  synth                    Path prefix of the synth graph [default: synth].

Command: workload [options] [<workload1,workload2,...>]
Executes one or more workloads. Available workloads: count-vertices|count-edges|degree|in-degree|out-degree|pagerank|bfs|neighbors|in-neighbors|out-neighbors|in-edges|out-edges|connected-components|triangle-count|strongly-connected-components|betweenness-centrality|closeness-centrality|sssp|subgraph-isomorphism|all 
  -b, --backend <value>    Workload backend. Supported: spark|neo4j [default: spark].
  -i, --iterations <num>   Number of algorithm's iterations. Required by: strongly-connected-components|betweenness-centrality [default:].
  -s, --source <id>        The source vertex ID. Required by: bfs|closeness-centrality|sssp [default: random].
  -d, --destination <id>   The destination vertex ID. Required by: bfs [default: random].
  -t, --pattern <path>     Path prefix of the pattern graph. Required by: subgraph-isomorphism [default: pattern].
  -g, --graph <path>       Path prefix of the graph [default: graph].
  <workload1,workload2,...>
                           Comma separated list of workloads to execute [default: all].
```