### PR TITLE
Neo4j subgraph isomorphism update

### DIFF
--- a/neo4j-plugins/subgraph-isomorphism/README.md
+++ b/neo4j-plugins/subgraph-isomorphism/README.md
@@ -1,6 +1,6 @@
 # subgraph-isomorphism-neo4j
 
-This project under @msstate-dasi provides a subgraph isomorphism Java plugin for Neo4j database. Given a pattern graph and a target graph, it calculates all possible subgraphs of the target graph isomorphic to the pattern graph. Both the pattern graph and target graph are stored in the same Neo4j database. Currently it utilized the Ullmann's algorithm and works only with undirected graphs (ignore directions in a directional graph).
+This project under @msstate-dasi provides a subgraph isomorphism Java plugin for Neo4j database. Given a pattern graph and a target graph, it calculates all possible subgraphs of the target graph isomorphic to the pattern graph. Both the pattern graph and target graph are stored in the same Neo4j database. Currently it utilized the Ullmann's algorithm and works on both directed and undirected graphs.
 
 ## Compile: 
 

--- a/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/Result.java
+++ b/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/Result.java
@@ -15,10 +15,11 @@ public class Result {
      * Builds a Result object.
      *
      * @param subgraphIndex which subgraph does the resultNode belong to
-     * @param patternNode a node in the pattern graph
-     * @param targetNode a node in the isomorphic subgraph of the target graph
+     * @param patternNode   a node in the pattern graph
+     * @param targetNode    a node in the isomorphic subgraph of the target graph
      */
     public Result(Long subgraphIndex, Node patternNode, Node targetNode) {
+
         this.subgraphIndex = subgraphIndex;
         this.patternNode = patternNode;
         this.targetNode = targetNode;

--- a/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphIsomorphism.java
+++ b/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphIsomorphism.java
@@ -1,22 +1,24 @@
 package edu.msstate.dasi.csb.neo4j;
 
+import org.neo4j.graphdb.*;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
 import java.util.*;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.neo4j.graphdb.*;
-import org.neo4j.logging.Log;
-import org.neo4j.procedure.*;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-
 /**
  * Subgraph Isomorphism
  * A Java Plugin for Neo4j
  */
-public class SubgraphIsomorphism
-{
+public class SubgraphIsomorphism {
     @Context
     public GraphDatabaseAPI db;
 
@@ -27,9 +29,9 @@ public class SubgraphIsomorphism
     @Description("Given the pattern graph label and the target graph label, execute subgraph isomorphism algorithm " +
             "and return subgraphs. CALL csb.subgraphIsomorphism(patternLabel, targetLabel) YIELD subgraphIndex, " +
             "patternNode, targetNode")
-    public Stream<Result> subgraphIsomorphism( @Name("patternLabel") String patternLabelString,
-                                               @Name("targetLabel") String targetLabelString,
-                                               @Name(value = "parallelFactor", defaultValue = "2") Long parallelFactor ) {
+    public Stream<Result> subgraphIsomorphism(@Name("patternLabel") String patternLabelString,
+                                              @Name("targetLabel") String targetLabelString,
+                                              @Name(value = "parallelFactor", defaultValue = "2") Long parallelFactor) {
         // The pattern label
         Label patternLabel = Label.label(patternLabelString);
 
@@ -39,41 +41,37 @@ public class SubgraphIsomorphism
         // The available number of CPU cores
         int numCores = Runtime.getRuntime().availableProcessors();
 
-        ForkJoinPool threadPool = new ForkJoinPool(numCores*parallelFactor.intValue());
+        ForkJoinPool threadPool = new ForkJoinPool(numCores * parallelFactor.intValue());
 
         // The list that stores all pattern nodes
         ArrayList<Node> patternNodeList = new ArrayList<>();
 
         // Execute the algorithm
-        List<List<Node>> matchedSubgraphs = ullmannAlg(patternLabel, targetLabel,patternNodeList,threadPool);
+        List<List<Node>> matchedSubgraphs = ullmannAlg(patternLabel, targetLabel, patternNodeList, threadPool);
 
         ArrayList<Result> resultList = new ArrayList<>();
 
-        try
-        {
+        try {
             /* Return the results.
              * Each row of the matchedSubgraphs contains nodes in a matched subgraph ordered by the pattern nodes in
              * the patternNodeList, i.e., patternNodeList.size()==matchedSubgraphs.get(i).size();
              */
 
-                if (matchedSubgraphs.isEmpty()) return null;
+            if (matchedSubgraphs.isEmpty()) return null;
 
-                else
-                {
+            else {
 
-                    for (Long i = 0L; i < matchedSubgraphs.size(); i++)
-                    {
+                for (Long i = 0L; i < matchedSubgraphs.size(); i++) {
 
-                        for (int j = 0; j < matchedSubgraphs.get(i.intValue()).size(); j++)
-                            resultList.add(new Result(i, patternNodeList.get(j), matchedSubgraphs.get(i.intValue()).get(j)));
+                    for (int j = 0; j < matchedSubgraphs.get(i.intValue()).size(); j++)
+                        resultList.add(new Result(i, patternNodeList.get(j), matchedSubgraphs.get(i.intValue()).get(j)));
 
-                    }
-
-                    return resultList.stream();
                 }
 
-        } catch (Exception e)
-        {
+                return resultList.stream();
+            }
+
+        } catch (Exception e) {
 
             String errMsg = "Error encountered while calculating subgraph isomorphism.";
 
@@ -103,7 +101,7 @@ public class SubgraphIsomorphism
         // Stores the final results
         List<List<Node>> matchedSubgraphs = new ArrayList<>();
 
-        try( Transaction tx = db.beginTx() ) {
+        try (Transaction tx = db.beginTx()) {
             /* Create the neighbor list for the Neo4j database with the target label **********************************/
 
             ResourceIterator<Node> targetNodes;
@@ -111,27 +109,27 @@ public class SubgraphIsomorphism
             ArrayList<Node> targetNeighborListIndex = new ArrayList<>();
 
             // Given a node, get the index in the node neighbor list
-            Map<Node,Integer> targetNeighborListMap = new HashMap<>();
+            Map<Node, Integer> targetNeighborListMap = new HashMap<>();
 
             if (targetLabel.name().equals("")) targetNodes = db.getAllNodes().iterator();
             else targetNodes = db.findNodes(targetLabel);
 
-            int index=0;
+            int index = 0;
 
             while (targetNodes.hasNext()) {
 
                 Node targetNode = targetNodes.next();
 
                 // Pass the pattern graph nodes if the whole neo4j database is selected
-                if ( targetLabel.name().equals("") && targetNode.hasLabel(patternLabel) ) continue;
+                if (targetLabel.name().equals("") && targetNode.hasLabel(patternLabel)) continue;
 
-                targetInNeighborList.add(findNodeNeighbors(targetNode, targetLabel,false));
+                targetInNeighborList.add(findNodeNeighbors(targetNode, targetLabel, false));
 
-                targetOutNeighborList.add(findNodeNeighbors(targetNode, targetLabel,true));
+                targetOutNeighborList.add(findNodeNeighbors(targetNode, targetLabel, true));
 
                 targetNeighborListIndex.add(targetNode);
 
-                targetNeighborListMap.put(targetNode,index);
+                targetNeighborListMap.put(targetNode, index);
 
                 index++;
             }
@@ -140,15 +138,14 @@ public class SubgraphIsomorphism
 
             /* Create the candidate list and its index ****************************************************************/
 
-            Map<Node,Integer> candidateListMap = new HashMap<>();
+            Map<Node, Integer> candidateListMap = new HashMap<>();
 
             List<List<Node>> candidateList = findCandidates(patternLabel, candidateListMap, targetInNeighborList, targetOutNeighborList,
                     targetNeighborListIndex, patternNodeList, threadPool);
 
             /* Create the pattern graph's neighbor lists ***************************************************************/
 
-            patternNodeList.forEach(node ->
-            {
+            patternNodeList.forEach(node -> {
 
                 patternInNeighborList.add(new ArrayList<>());
 
@@ -156,11 +153,10 @@ public class SubgraphIsomorphism
 
             });
 
-            patternNodeList.parallelStream().forEach(node ->
-            {
-                try(Transaction tx1 = db.beginTx()) {
+            patternNodeList.parallelStream().forEach(node -> {
+                try (Transaction tx1 = db.beginTx()) {
 
-                    patternInNeighborList.set(candidateListMap.get(node), findNodeNeighbors(node, patternLabel,false));
+                    patternInNeighborList.set(candidateListMap.get(node), findNodeNeighbors(node, patternLabel, false));
 
                     patternOutNeighborList.set(candidateListMap.get(node), findNodeNeighbors(node, patternLabel, true));
 
@@ -173,8 +169,7 @@ public class SubgraphIsomorphism
 
             refineCandidate(candidateList, patternInNeighborList, patternOutNeighborList, targetInNeighborList, targetOutNeighborList, candidateListMap, targetNeighborListMap);
 
-            if ( ! isCorrect(candidateList) )
-            {
+            if (!isCorrect(candidateList)) {
 
                 tx.success();
 
@@ -191,20 +186,18 @@ public class SubgraphIsomorphism
 
             final long splitSize = (jobSize > threadPoolSize * 2) ? jobSize / (threadPoolSize * 2) : 1;
 
-            SubgraphProcessor mainProcessor = new SubgraphProcessor(candidateList,candidateListMap,
+            SubgraphProcessor mainProcessor = new SubgraphProcessor(candidateList, candidateListMap,
                     patternInNeighborList, patternOutNeighborList,
-                    targetInNeighborList,targetOutNeighborList,targetNeighborListMap,
+                    targetInNeighborList, targetOutNeighborList, targetNeighborListMap,
                     splitSize, threadPool);
 
             Future<List<List<Node>>> futureMatchedSubgraphs = threadPool.submit(mainProcessor);
 
-            try
-            {
+            try {
 
                 matchedSubgraphs.addAll(futureMatchedSubgraphs.get());
 
-            } catch (Exception e)
-            {
+            } catch (Exception e) {
 
                 e.printStackTrace();
             }
@@ -221,10 +214,9 @@ public class SubgraphIsomorphism
     /**
      * Check if the current candidate list is correct. (i.e., is there any empty candidate list?)
      */
-    private boolean isCorrect(List<List<Node>> candidateList)
-    {
-        for (List<Node> aCandidateList : candidateList)
-        {
+    private boolean isCorrect(List<List<Node>> candidateList) {
+
+        for (List<Node> aCandidateList : candidateList) {
 
             if (aCandidateList.isEmpty()) return false;
 
@@ -242,16 +234,14 @@ public class SubgraphIsomorphism
                                  List<List<Node>> targetInNeighborList,
                                  List<List<Node>> targetOutNeighborList,
                                  Map<Node, Integer> candidateListMap,
-                                 Map<Node, Integer> targetNeighborListMap)
-    {
+                                 Map<Node, Integer> targetNeighborListMap) {
 
         List<List<Node>> nodesToRemove = new ArrayList<>();
 
         // Create the list of node that should be removed
         candidateList.forEach(list -> nodesToRemove.add(new ArrayList<>()));
 
-        IntStream.range(0, candidateList.size()).parallel().forEach(ii -> candidateList.get(ii).forEach(node ->
-        {
+        IntStream.range(0, candidateList.size()).parallel().forEach(ii -> candidateList.get(ii).forEach(node -> {
 
             boolean inRefinable = patternInNeighborList.get(ii).parallelStream().allMatch(qnode ->
                     candidateList.get(candidateListMap.get(qnode)).parallelStream().anyMatch(subnode ->
@@ -275,33 +265,31 @@ public class SubgraphIsomorphism
                                             List<List<Node>> targetInNeighborList, List<List<Node>> targetOutNeighborList,
                                             ArrayList<Node> targetNeighborListIndex,
                                             ArrayList<Node> patternNodeList,
-                                            ForkJoinPool threadPool)
-    {
+                                            ForkJoinPool threadPool) {
         // Input an empty candidate-list index list for modification
         List<List<Node>> candidateList = new ArrayList<>();
 
-        try(Transaction tx = db.beginTx())
-        {
+        try (Transaction tx = db.beginTx()) {
+
             ResourceIterator<Node> patternNodes = db.findNodes(patternLabel);
 
-            while (patternNodes.hasNext())
-            {
+            while (patternNodes.hasNext()) {
+
                 ArrayList<Node> candidateListPerVertex = new ArrayList<>();
 
                 Node patternNode = patternNodes.next();
 
-                int patternInDegree=patternNode.getDegree(Direction.INCOMING);
+                int patternInDegree = patternNode.getDegree(Direction.INCOMING);
 
-                int patternOutDegree=patternNode.getDegree(Direction.OUTGOING);
+                int patternOutDegree = patternNode.getDegree(Direction.OUTGOING);
 
-                for(int i=0;i<targetNeighborListIndex.size();i++)
-                {
+                for (int i = 0; i < targetNeighborListIndex.size(); i++) {
 
-                    int targetInDegree=targetInNeighborList.get(i).size();
+                    int targetInDegree = targetInNeighborList.get(i).size();
 
-                    int targetOutDegree=targetOutNeighborList.get(i).size();
+                    int targetOutDegree = targetOutNeighborList.get(i).size();
 
-                    if(targetInDegree>=patternInDegree && targetOutDegree>=patternOutDegree)
+                    if (targetInDegree >= patternInDegree && targetOutDegree >= patternOutDegree)
                         candidateListPerVertex.add(targetNeighborListIndex.get(i));
                 }
 
@@ -318,26 +306,25 @@ public class SubgraphIsomorphism
 
             //make the size of the first element in the candidiate list close to 2*threadPoolSize
 
-            int swapPoint=candidateList.size()-1;
+            int swapPoint = candidateList.size() - 1;
 
-            for(int i=0;i<candidateList.size();i++)
-            {
-                if (candidateList.get(i).size()>=(threadPool.getParallelism()*2+1))
-                {//consider also the temporarily appended node
-                    swapPoint=i;
+            for (int i = 0; i < candidateList.size(); i++) {
+
+                if (candidateList.get(i).size() >= (threadPool.getParallelism() * 2 + 1)) {//consider also the temporarily appended node
+                    swapPoint = i;
 
                     break;
                 }
             }
 
-            if(swapPoint!=0)
-                Collections.swap(candidateList,0,swapPoint);
+            if (swapPoint != 0)
+                Collections.swap(candidateList, 0, swapPoint);
 
-            for (int i=0; i < candidateList.size(); i++)
-            {
+            for (int i = 0; i < candidateList.size(); i++) {
+
                 patternNodeList.add(candidateList.get(i).get(0));
 
-                candidateListMap.put(candidateList.get(i).get(0),i);
+                candidateListMap.put(candidateList.get(i).get(0), i);
             }
 
             // Remove the temporary pattern node at position 0
@@ -354,26 +341,22 @@ public class SubgraphIsomorphism
      * Find the neighbors of a node in the Neo4j database,
      * either incoming or outgoing
      */
-    private ArrayList<Node> findNodeNeighbors(Node node, Label targetLabel, boolean isOutGoing)
-    {//find the neighbors of a node in the Neo4j database
+    private ArrayList<Node> findNodeNeighbors(Node node, Label targetLabel, boolean isOutGoing) {//find the neighbors of a node in the Neo4j database
         //isOutGoing (direction):false-incoming, true-outgoing
 
-        ArrayList<Node> neighborsOfnode=new ArrayList<>();
+        ArrayList<Node> neighborsOfnode = new ArrayList<>();
 
-        Iterator<Relationship> relationships=isOutGoing?node.getRelationships(Direction.OUTGOING).iterator():node.getRelationships(Direction.INCOMING).iterator();
+        Iterator<Relationship> relationships = isOutGoing ? node.getRelationships(Direction.OUTGOING).iterator() : node.getRelationships(Direction.INCOMING).iterator();
 
-        while(relationships.hasNext()){
+        while (relationships.hasNext()) {
 
-            Node neighborNode=relationships.next().getOtherNode(node);
+            Node neighborNode = relationships.next().getOtherNode(node);
 
-            if (targetLabel.name().equals("All"))
-            {
+            if (targetLabel.name().equals("All")) {
 
                 neighborsOfnode.add(neighborNode);
 
-            }
-            else if (neighborNode.hasLabel(targetLabel))
-            {
+            } else if (neighborNode.hasLabel(targetLabel)) {
 
                 neighborsOfnode.add(neighborNode);// only add nodes that have the target label and ignore others
 

--- a/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphIsomorphism.java
+++ b/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphIsomorphism.java
@@ -63,8 +63,9 @@ public class SubgraphIsomorphism {
 
                 for (Long i = 0L; i < matchedSubgraphs.size(); i++) {
 
-                    for (int j = 0; j < matchedSubgraphs.get(i.intValue()).size(); j++)
+                    for (int j = 0; j < matchedSubgraphs.get(i.intValue()).size(); j++) {
                         resultList.add(new Result(i, patternNodeList.get(j), matchedSubgraphs.get(i.intValue()).get(j)));
+                    }
 
                 }
 
@@ -251,8 +252,7 @@ public class SubgraphIsomorphism {
                     candidateList.get(candidateListMap.get(qnode)).parallelStream().anyMatch(subnode ->
                             targetOutNeighborList.get(targetNeighborListMap.get(node)).contains(subnode)));
 
-            if (!(inRefinable && outRefinable))
-                nodesToRemove.get(ii).add(node);
+            if (!(inRefinable && outRefinable)) nodesToRemove.get(ii).add(node);
 
         }));
     }
@@ -317,8 +317,7 @@ public class SubgraphIsomorphism {
                 }
             }
 
-            if (swapPoint != 0)
-                Collections.swap(candidateList, 0, swapPoint);
+            if (swapPoint != 0) Collections.swap(candidateList, 0, swapPoint);
 
             for (int i = 0; i < candidateList.size(); i++) {
 

--- a/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphIsomorphism.java
+++ b/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphIsomorphism.java
@@ -49,36 +49,56 @@ public class SubgraphIsomorphism
 
         ArrayList<Result> resultList = new ArrayList<>();
 
-        try {
+        try
+        {
             /* Return the results.
              * Each row of the matchedSubgraphs contains nodes in a matched subgraph ordered by the pattern nodes in
              * the patternNodeList, i.e., patternNodeList.size()==matchedSubgraphs.get(i).size();
              */
 
-            if (matchedSubgraphs.isEmpty()) return null;
-            else {
-                for (Long i = 0L; i < matchedSubgraphs.size(); i++) {
-                    for (int j = 0; j < matchedSubgraphs.get(i.intValue()).size(); j++) {
-                        resultList.add(new Result(i, patternNodeList.get(j), matchedSubgraphs.get(i.intValue()).get(j)));
+                if (matchedSubgraphs.isEmpty()) return null;
+
+                else
+                {
+
+                    for (Long i = 0L; i < matchedSubgraphs.size(); i++)
+                    {
+
+                        for (int j = 0; j < matchedSubgraphs.get(i.intValue()).size(); j++)
+                            resultList.add(new Result(i, patternNodeList.get(j), matchedSubgraphs.get(i.intValue()).get(j)));
+
                     }
+
+                    return resultList.stream();
                 }
-                return resultList.stream();
-            }
-        } catch (Exception e) {
+
+        } catch (Exception e)
+        {
+
             String errMsg = "Error encountered while calculating subgraph isomorphism.";
+
             log.error(errMsg, e);
-            throw new RuntimeException(errMsg, e);}
+
+            throw new RuntimeException(errMsg, e);
+        }
     }
 
     private List<List<Node>> ullmannAlg(Label patternLabel,
                                         Label targetLabel,
                                         ArrayList<Node> patternNodeList,
                                         ForkJoinPool threadPool) {
-        // The neighbor list for pattern vertices
-        List<List<Node>> patternNeighborList = new ArrayList<>();
 
-        // The neighbor list for the Neo4j database with the target label
-        List<List<Node>> nodeNeighborList = new ArrayList<>();
+        /* The incoming and outgoing neighbor lists of pattern vertices and target vertices are for supporting directed graphs************/
+
+        // The incoming and outgoing neighbor lists for pattern vertices
+        List<List<Node>> patternInNeighborList = new ArrayList<>();
+
+        List<List<Node>> patternOutNeighborList = new ArrayList<>();
+
+        // The incoming and outgoing neighbor lists for the Neo4j database with the target label
+        List<List<Node>> targetInNeighborList = new ArrayList<>();
+
+        List<List<Node>> targetOutNeighborList = new ArrayList<>();
 
         // Stores the final results
         List<List<Node>> matchedSubgraphs = new ArrayList<>();
@@ -87,24 +107,32 @@ public class SubgraphIsomorphism
             /* Create the neighbor list for the Neo4j database with the target label **********************************/
 
             ResourceIterator<Node> targetNodes;
-            ArrayList<Node> nodeNeighborListIndex = new ArrayList<>();
+
+            ArrayList<Node> targetNeighborListIndex = new ArrayList<>();
 
             // Given a node, get the index in the node neighbor list
-            Map<Node,Integer> nodeNeighborListMap = new HashMap<>();
+            Map<Node,Integer> targetNeighborListMap = new HashMap<>();
 
             if (targetLabel.name().equals("")) targetNodes = db.getAllNodes().iterator();
             else targetNodes = db.findNodes(targetLabel);
 
             int index=0;
+
             while (targetNodes.hasNext()) {
+
                 Node targetNode = targetNodes.next();
 
                 // Pass the pattern graph nodes if the whole neo4j database is selected
                 if ( targetLabel.name().equals("") && targetNode.hasLabel(patternLabel) ) continue;
 
-                nodeNeighborList.add(findNodeNeighbors(targetNode, targetLabel));
-                nodeNeighborListIndex.add(targetNode);
-                nodeNeighborListMap.put(targetNode,index);
+                targetInNeighborList.add(findNodeNeighbors(targetNode, targetLabel,false));
+
+                targetOutNeighborList.add(findNodeNeighbors(targetNode, targetLabel,true));
+
+                targetNeighborListIndex.add(targetNode);
+
+                targetNeighborListMap.put(targetNode,index);
+
                 index++;
             }
 
@@ -113,53 +141,79 @@ public class SubgraphIsomorphism
             /* Create the candidate list and its index ****************************************************************/
 
             Map<Node,Integer> candidateListMap = new HashMap<>();
-            List<List<Node>> candidateList = findCandidates(patternLabel, candidateListMap, nodeNeighborList,
-                    nodeNeighborListIndex,patternNodeList);
 
-            /* Create the pattern graph's neighbor list ***************************************************************/
+            List<List<Node>> candidateList = findCandidates(patternLabel, candidateListMap, targetInNeighborList, targetOutNeighborList,
+                    targetNeighborListIndex, patternNodeList, threadPool);
 
-            patternNodeList.forEach(node -> patternNeighborList.add(new ArrayList<>()));
-            patternNodeList.parallelStream().forEach(node -> {
+            /* Create the pattern graph's neighbor lists ***************************************************************/
+
+            patternNodeList.forEach(node ->
+            {
+
+                patternInNeighborList.add(new ArrayList<>());
+
+                patternOutNeighborList.add(new ArrayList<>());
+
+            });
+
+            patternNodeList.parallelStream().forEach(node ->
+            {
                 try(Transaction tx1 = db.beginTx()) {
-                    patternNeighborList.set(candidateListMap.get(node), findNodeNeighbors(node, patternLabel));
+
+                    patternInNeighborList.set(candidateListMap.get(node), findNodeNeighbors(node, patternLabel,false));
+
+                    patternOutNeighborList.set(candidateListMap.get(node), findNodeNeighbors(node, patternLabel, true));
+
                     tx1.success();
+
                 }
             });
 
             /* Refine the candidate list preliminarily, check if it is valid ******************************************/
 
-            refineCandidate(candidateList, patternNeighborList, nodeNeighborList, candidateListMap, nodeNeighborListMap);
-            if ( ! isCorrect(candidateList) ) {
+            refineCandidate(candidateList, patternInNeighborList, patternOutNeighborList, targetInNeighborList, targetOutNeighborList, candidateListMap, targetNeighborListMap);
+
+            if ( ! isCorrect(candidateList) )
+            {
+
                 tx.success();
+
                 return matchedSubgraphs;
+
             }
 
-            /* Store the size of each element in the candidate list in an array ***************************************/
-            int[] candidateListSize = new int[candidateList.size()];
-
-            for (int i = 0; i < candidateList.size(); i++) {
-                candidateListSize[i] = candidateList.get(i).size();
-            }
 
             /* Begin multithreading execution of the algorithm ********************************************************/
 
             int threadPoolSize = threadPool.getParallelism();
+
             int jobSize = candidateList.get(0).size();
+
             final long splitSize = (jobSize > threadPoolSize * 2) ? jobSize / (threadPoolSize * 2) : 1;
-            SubgraphProcessor mainProcessor = new SubgraphProcessor(candidateList,candidateListMap,candidateListSize,
-                    patternNeighborList, nodeNeighborList,nodeNeighborListMap,splitSize, threadPool);
+
+            SubgraphProcessor mainProcessor = new SubgraphProcessor(candidateList,candidateListMap,
+                    patternInNeighborList, patternOutNeighborList,
+                    targetInNeighborList,targetOutNeighborList,targetNeighborListMap,
+                    splitSize, threadPool);
 
             Future<List<List<Node>>> futureMatchedSubgraphs = threadPool.submit(mainProcessor);
 
-            try {
+            try
+            {
+
                 matchedSubgraphs.addAll(futureMatchedSubgraphs.get());
-            } catch (Exception e) {
+
+            } catch (Exception e)
+            {
+
                 e.printStackTrace();
             }
 
             threadPool.shutdown();
+
             tx.success();
         }
+
         return matchedSubgraphs;
     }
 
@@ -167,43 +221,50 @@ public class SubgraphIsomorphism
     /**
      * Check if the current candidate list is correct. (i.e., is there any empty candidate list?)
      */
-    private boolean isCorrect(List<List<Node>> candidateList) {
-        for (List<Node> aCandidateList : candidateList) {
+    private boolean isCorrect(List<List<Node>> candidateList)
+    {
+        for (List<Node> aCandidateList : candidateList)
+        {
+
             if (aCandidateList.isEmpty()) return false;
+
         }
+
         return true;
     }
 
     /**
-     * Given the three lists, refine the candidate list
+     * Given the candidate and neighbor lists, refine the candidate list
      */
     private void refineCandidate(List<List<Node>> candidateList,
-                                 List<List<Node>> patternNeighborList,
-                                 List<List<Node>> nodeNeighborList,
+                                 List<List<Node>> patternInNeighborList,
+                                 List<List<Node>> patternOutNeighborList,
+                                 List<List<Node>> targetInNeighborList,
+                                 List<List<Node>> targetOutNeighborList,
                                  Map<Node, Integer> candidateListMap,
-                                 Map<Node, Integer> nodeNeighborListMap) {
-        // Check if there are empty entries in the candidate list
-        for (List<Node> list: candidateList) {
-            if ( list.size() == 0 ) return;
-        }
+                                 Map<Node, Integer> targetNeighborListMap)
+    {
 
         List<List<Node>> nodesToRemove = new ArrayList<>();
 
         // Create the list of node that should be removed
         candidateList.forEach(list -> nodesToRemove.add(new ArrayList<>()));
 
-        IntStream.range(0,candidateList.size()).parallel().forEach( ii -> candidateList.get(ii).forEach(node -> {
-            boolean refinable = patternNeighborList.get(ii).parallelStream().allMatch(qnode ->
+        IntStream.range(0, candidateList.size()).parallel().forEach(ii -> candidateList.get(ii).forEach(node ->
+        {
+
+            boolean inRefinable = patternInNeighborList.get(ii).parallelStream().allMatch(qnode ->
                     candidateList.get(candidateListMap.get(qnode)).parallelStream().anyMatch(subnode ->
-                            nodeNeighborList.get(nodeNeighborListMap.get(node)).contains(subnode)));
+                            targetInNeighborList.get(targetNeighborListMap.get(node)).contains(subnode)));
 
-            if ( ! refinable ) nodesToRemove.get(ii).add(node);
+            boolean outRefinable = patternOutNeighborList.get(ii).parallelStream().allMatch(qnode ->
+                    candidateList.get(candidateListMap.get(qnode)).parallelStream().anyMatch(subnode ->
+                            targetOutNeighborList.get(targetNeighborListMap.get(node)).contains(subnode)));
+
+            if (!(inRefinable && outRefinable))
+                nodesToRemove.get(ii).add(node);
+
         }));
-
-        // Now remove the nodes from the candidate list
-        for (int i=0; i < candidateList.size(); i++) {
-            candidateList.get(i).removeAll(nodesToRemove.get(i));
-        }
     }
 
     /**
@@ -211,62 +272,113 @@ public class SubgraphIsomorphism
      */
     private List<List<Node>> findCandidates(Label patternLabel,
                                             Map<Node, Integer> candidateListMap,
-                                            List<List<Node>> nodeNeighborList,
-                                            ArrayList<Node> nodeNeighborListIndex,
-                                            ArrayList<Node> patternNodeList) {
+                                            List<List<Node>> targetInNeighborList, List<List<Node>> targetOutNeighborList,
+                                            ArrayList<Node> targetNeighborListIndex,
+                                            ArrayList<Node> patternNodeList,
+                                            ForkJoinPool threadPool)
+    {
         // Input an empty candidate-list index list for modification
         List<List<Node>> candidateList = new ArrayList<>();
 
-        try(Transaction tx = db.beginTx()) {
+        try(Transaction tx = db.beginTx())
+        {
             ResourceIterator<Node> patternNodes = db.findNodes(patternLabel);
 
-            while (patternNodes.hasNext()) {
+            while (patternNodes.hasNext())
+            {
                 ArrayList<Node> candidateListPerVertex = new ArrayList<>();
-                Node patternNode = patternNodes.next();
-                int patternNodeDegree = findNodeNeighbors(patternNode, patternLabel).size();
 
-                for (int i = 0; i < nodeNeighborList.size(); i++) {
-                    int targetNodeDegree = nodeNeighborList.get(i).size();
-                    if (targetNodeDegree >= patternNodeDegree)
-                        candidateListPerVertex.add(nodeNeighborListIndex.get(i));
+                Node patternNode = patternNodes.next();
+
+                int patternInDegree=patternNode.getDegree(Direction.INCOMING);
+
+                int patternOutDegree=patternNode.getDegree(Direction.OUTGOING);
+
+                for(int i=0;i<targetNeighborListIndex.size();i++)
+                {
+
+                    int targetInDegree=targetInNeighborList.get(i).size();
+
+                    int targetOutDegree=targetOutNeighborList.get(i).size();
+
+                    if(targetInDegree>=patternInDegree && targetOutDegree>=patternOutDegree)
+                        candidateListPerVertex.add(targetNeighborListIndex.get(i));
                 }
+
                 // Temporarily append the pattern node to the first position of the list
                 candidateListPerVertex.add(0, patternNode);
+
                 candidateList.add(candidateListPerVertex);
             }
 
             // Sort the candidate list by the number of candidates (ascending)
             Comparator<List<Node>> candidateListSizeComparator = Comparator.comparingInt(List::size);
+
             candidateList.sort(candidateListSizeComparator);
 
-            for (int i=0; i < candidateList.size(); i++) {
+            //make the size of the first element in the candidiate list close to 2*threadPoolSize
+
+            int swapPoint=candidateList.size()-1;
+
+            for(int i=0;i<candidateList.size();i++)
+            {
+                if (candidateList.get(i).size()>=(threadPool.getParallelism()*2+1))
+                {//consider also the temporarily appended node
+                    swapPoint=i;
+
+                    break;
+                }
+            }
+
+            if(swapPoint!=0)
+                Collections.swap(candidateList,0,swapPoint);
+
+            for (int i=0; i < candidateList.size(); i++)
+            {
                 patternNodeList.add(candidateList.get(i).get(0));
+
                 candidateListMap.put(candidateList.get(i).get(0),i);
             }
 
             // Remove the temporary pattern node at position 0
             candidateList.forEach(nodes -> nodes.remove(0));
+
             patternNodes.close();
+
             tx.success();
         }
         return candidateList;
     }
 
     /**
-     * Find the neighbors of a node in the Neo4j database
+     * Find the neighbors of a node in the Neo4j database,
+     * either incoming or outgoing
      */
-    private ArrayList<Node> findNodeNeighbors(Node node, Label targetLabel) {
-        ArrayList<Node> neighborsOfnode = new ArrayList<>();
+    private ArrayList<Node> findNodeNeighbors(Node node, Label targetLabel, boolean isOutGoing)
+    {//find the neighbors of a node in the Neo4j database
+        //isOutGoing (direction):false-incoming, true-outgoing
 
-        for (Relationship relationship : node.getRelationships()) {
-            Node neighborNode = relationship.getOtherNode(node);
+        ArrayList<Node> neighborsOfnode=new ArrayList<>();
 
-            if (targetLabel.name().equals("")) {
+        Iterator<Relationship> relationships=isOutGoing?node.getRelationships(Direction.OUTGOING).iterator():node.getRelationships(Direction.INCOMING).iterator();
+
+        while(relationships.hasNext()){
+
+            Node neighborNode=relationships.next().getOtherNode(node);
+
+            if (targetLabel.name().equals("All"))
+            {
+
                 neighborsOfnode.add(neighborNode);
-            } else if (neighborNode.hasLabel(targetLabel)) {
-                // Only add nodes that have the target label and ignore others
-                neighborsOfnode.add(neighborNode);
+
             }
+            else if (neighborNode.hasLabel(targetLabel))
+            {
+
+                neighborsOfnode.add(neighborNode);// only add nodes that have the target label and ignore others
+
+            }
+
         }
         return neighborsOfnode;
     }

--- a/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphProcessor.java
+++ b/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphProcessor.java
@@ -1,32 +1,37 @@
 package edu.msstate.dasi.csb.neo4j;
 
-import java.util.*;
+import org.neo4j.graphdb.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveTask;
 import java.util.stream.IntStream;
-import org.neo4j.graphdb.*;
 
-public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
-    private List<List<Node>> candidateList;
-    final private Map<Node,Integer> candidateNode2Index;
+public class SubgraphProcessor extends RecursiveTask<List<List<Node>>> {
+
+    final private Map<Node, Integer> candidateNode2Index;
     final private List<List<Node>> patternInNeighborList;
     final private List<List<Node>> patternOutNeighborList;
     final private List<List<Node>> targetInNeighborList;
     final private List<List<Node>> targetOutNeighborList;
-    final private Map<Node,Integer> nodeNeighborListMap;
+    final private Map<Node, Integer> nodeNeighborListMap;
     final private int lo;
     final private int hi;
     final private ForkJoinPool threadPool;
-    private List<List<Node>> matchedSubgraphs;
     final private long splitSize;
+    private List<List<Node>> candidateList;
+    private List<List<Node>> matchedSubgraphs;
 
     SubgraphProcessor(List<List<Node>> candidateList,
                       Map<Node, Integer> candidateNode2Index,
                       List<List<Node>> patternInNeighborList, List<List<Node>> patternOutNeighborList,
-                      List<List<Node>> targetInNeighborList,  List<List<Node>> targetOutNeighborList,
-                      Map<Node,Integer> nodeNeighborListMap,
+                      List<List<Node>> targetInNeighborList, List<List<Node>> targetOutNeighborList,
+                      Map<Node, Integer> nodeNeighborListMap,
                       long splitSize,
                       ForkJoinPool threadPool) {
+
         this.lo = 0;
         this.hi = candidateList.get(0).size();
         this.candidateList = candidateList;
@@ -43,20 +48,16 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
     }
 
     @Override
-    protected List<List<Node>> compute()
-    {
+    protected List<List<Node>> compute() {
         // Assign tasks to different threads
-        List<SubgraphProcessor> tasks=new ArrayList<>();
+        List<SubgraphProcessor> tasks = new ArrayList<>();
 
-        if( hi - lo <= splitSize )
-        {
+        if (hi - lo <= splitSize) {
             // A task is small enough for a single thread
             matchedSubgraphs.addAll(backtracking(0, candidateList, candidateNode2Index,
                     patternInNeighborList, patternOutNeighborList,
                     targetInNeighborList, targetOutNeighborList, nodeNeighborListMap));
-        }
-        else
-        {
+        } else {
             // A task is going to be split in half
             int mid = (lo + hi) >>> 1;
 
@@ -65,12 +66,12 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
             List<List<Node>> rightCandidateList = copyNodeList(candidateList, mid, hi);
 
             SubgraphProcessor forkedTask1 = new SubgraphProcessor(leftCandidateList, candidateNode2Index,
-                     patternInNeighborList, patternOutNeighborList,
+                    patternInNeighborList, patternOutNeighborList,
                     targetInNeighborList, targetOutNeighborList, nodeNeighborListMap,
                     splitSize, threadPool);
 
             SubgraphProcessor forkedTask2 = new SubgraphProcessor(rightCandidateList, candidateNode2Index,
-                     patternInNeighborList, patternOutNeighborList,
+                    patternInNeighborList, patternOutNeighborList,
                     targetInNeighborList, targetOutNeighborList, nodeNeighborListMap,
                     splitSize, threadPool);
 
@@ -82,7 +83,7 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
 
             tasks.add(forkedTask2);
 
-            collectResultsFromTasks(matchedSubgraphs,tasks);
+            collectResultsFromTasks(matchedSubgraphs, tasks);
         }
 
         return matchedSubgraphs;
@@ -96,10 +97,9 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
                                           Map<Node, Integer> candidateNode2Index,
                                           List<List<Node>> patternInNeighborList, List<List<Node>> patternOutNeighborList,
                                           List<List<Node>> targetInNeighborList, List<List<Node>> targetOutNeighborList,
-                                          Map<Node, Integer> nodeNeighborListMap)
-    {
+                                          Map<Node, Integer> nodeNeighborListMap) {
 
-        List<List<Node>> matchedSubgraphs=new ArrayList<>();
+        List<List<Node>> matchedSubgraphs = new ArrayList<>();
 
         if (numLayer == candidateList.size()) {
             // A matching subgraph is found
@@ -113,10 +113,10 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
             return matchedSubgraphs;
         }
 
-        List<List<Node>> originalCandidateList = copyNodeList(candidateList,0,candidateList.get(0).size());
+        List<List<Node>> originalCandidateList = copyNodeList(candidateList, 0, candidateList.get(0).size());
         // Retain the original copy of the candidateList for rolling back
-        for (int i=0; i < candidateList.get(numLayer).size(); i++)
-        {
+        for (int i = 0; i < candidateList.get(numLayer).size(); i++) {
+
             ArrayList<Node> singleNode = new ArrayList<>();
 
             singleNode.add(candidateList.get(numLayer).get(i));
@@ -128,15 +128,14 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
             removeUniqueNodes(singleNode.get(0), candidateList, numLayer);
 
             // Refine the candidate list
-            refineCandidate(candidateList,patternInNeighborList,patternOutNeighborList,targetInNeighborList,targetOutNeighborList,candidateNode2Index,nodeNeighborListMap);
+            refineCandidate(candidateList, patternInNeighborList, patternOutNeighborList, targetInNeighborList, targetOutNeighborList, candidateNode2Index, nodeNeighborListMap);
 
-            if( isCorrect(candidateList) )
-            {
+            if (isCorrect(candidateList)) {
                 // If the candidate list is valid, go to the next round recursively
                 List<List<Node>> pendingResult = backtracking(numLayer + 1, candidateList, candidateNode2Index,
-                         patternInNeighborList,patternOutNeighborList,targetInNeighborList,targetOutNeighborList, nodeNeighborListMap);
+                        patternInNeighborList, patternOutNeighborList, targetInNeighborList, targetOutNeighborList, nodeNeighborListMap);
 
-                if( ! pendingResult.isEmpty() ) matchedSubgraphs.addAll(pendingResult);
+                if (!pendingResult.isEmpty()) matchedSubgraphs.addAll(pendingResult);
             }
 
             // Resume the candidate list and continue searching
@@ -149,13 +148,13 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
     /**
      * Collect matching subgraphs from forked tasks
      */
-    private void collectResultsFromTasks(List<List<Node>> list, List<SubgraphProcessor> tasks)
-    {
-        for (SubgraphProcessor item:tasks) list.addAll(item.join());
+    private void collectResultsFromTasks(List<List<Node>> list, List<SubgraphProcessor> tasks) {
+
+        for (SubgraphProcessor item : tasks) list.addAll(item.join());
     }
 
-    private List<List<Node>> copyNodeList(List<List<Node>> originalList,int start, int end)
-    {
+    private List<List<Node>> copyNodeList(List<List<Node>> originalList, int start, int end) {
+
         List<List<Node>> copyList = new ArrayList<>();
 
         ArrayList<Node> firstRow = new ArrayList<>();
@@ -165,8 +164,7 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
 
         copyList.add(firstRow);
 
-        for (int i = 1; i < originalList.size(); i++)
-        {
+        for (int i = 1; i < originalList.size(); i++) {
             ArrayList<Node> temp = new ArrayList<>();
 
             temp.addAll(originalList.get(i));
@@ -186,16 +184,14 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
                                  List<List<Node>> targetInNeighborList,
                                  List<List<Node>> targetOutNeighborList,
                                  Map<Node, Integer> candidateListMap,
-                                 Map<Node, Integer> nodeNeighborListMap)
-    {
+                                 Map<Node, Integer> nodeNeighborListMap) {
 
         List<List<Node>> nodesToRemove = new ArrayList<>();
 
         // Create the list of node that should be removed
-        candidateList.forEach( list -> nodesToRemove.add(new ArrayList<>()) );
+        candidateList.forEach(list -> nodesToRemove.add(new ArrayList<>()));
 
-        IntStream.range(0,candidateList.size()).parallel().forEach(ii -> candidateList.get(ii).forEach(node ->
-        {
+        IntStream.range(0, candidateList.size()).parallel().forEach(ii -> candidateList.get(ii).forEach(node -> {
 
             boolean inRefinable = patternInNeighborList.get(ii).parallelStream().allMatch(qnode ->
                     candidateList.get(candidateListMap.get(qnode)).parallelStream().anyMatch(subnode ->
@@ -212,7 +208,7 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
 
         //Now remove the nodes from the candidate list
 
-        for (int i=0;i<candidateList.size();i++)
+        for (int i = 0; i < candidateList.size(); i++)
             candidateList.get(i).removeAll(nodesToRemove.get(i));
 
 
@@ -221,8 +217,8 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
     /**
      * Check if the current candidate list is correct. (i.e., is there any empty candidate list?)
      */
-    private boolean isCorrect(List<List<Node>> candidateList)
-    {
+    private boolean isCorrect(List<List<Node>> candidateList) {
+
         for (List<Node> aCandidateList : candidateList)
             if (aCandidateList.isEmpty()) return false;
 
@@ -235,11 +231,10 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
 
     private void removeUniqueNodes(Node unique,
                                    List<List<Node>> candidateList,
-                                   int layer)
-    {
+                                   int layer) {
 
-        for (int i = layer+1; i < candidateList.size(); i++)
-            if ( candidateList.get(i).contains(unique) ) candidateList.get(i).remove(unique);
+        for (int i = layer + 1; i < candidateList.size(); i++)
+            if (candidateList.get(i).contains(unique)) candidateList.get(i).remove(unique);
 
     }
 }

--- a/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphProcessor.java
+++ b/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphProcessor.java
@@ -105,8 +105,9 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>> {
             // A matching subgraph is found
             ArrayList<Node> subgraph = new ArrayList<>();
 
-            for (List<Node> aCandidateList : candidateList)
+            for (List<Node> aCandidateList : candidateList) {
                 subgraph.add(aCandidateList.get(0));
+            }
 
             matchedSubgraphs.add(subgraph);
 
@@ -159,8 +160,9 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>> {
 
         ArrayList<Node> firstRow = new ArrayList<>();
 
-        for (int k = start; k < end; k++)
+        for (int k = start; k < end; k++) {
             firstRow.add(originalList.get(0).get(k));
+        }
 
         copyList.add(firstRow);
 
@@ -219,22 +221,24 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>> {
      */
     private boolean isCorrect(List<List<Node>> candidateList) {
 
-        for (List<Node> aCandidateList : candidateList)
+        for (List<Node> aCandidateList : candidateList) {
             if (aCandidateList.isEmpty()) return false;
+        }
 
         return true;
     }
 
     /**
-     * Remove redundant apprearance of the unique node in the candidate list
+     * Remove redundant appearance of the unique node in the candidate list
      */
 
     private void removeUniqueNodes(Node unique,
                                    List<List<Node>> candidateList,
                                    int layer) {
 
-        for (int i = layer + 1; i < candidateList.size(); i++)
+        for (int i = layer + 1; i < candidateList.size(); i++) {
             if (candidateList.get(i).contains(unique)) candidateList.get(i).remove(unique);
+        }
 
     }
 }

--- a/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphProcessor.java
+++ b/neo4j-plugins/subgraph-isomorphism/src/main/java/edu/msstate/dasi/csb/neo4j/SubgraphProcessor.java
@@ -9,9 +9,10 @@ import org.neo4j.graphdb.*;
 public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
     private List<List<Node>> candidateList;
     final private Map<Node,Integer> candidateNode2Index;
-    final private int[] candidateListSize;
-    final private List<List<Node>> queryNeighborList;
-    final private List<List<Node>> nodeNeighborList;
+    final private List<List<Node>> patternInNeighborList;
+    final private List<List<Node>> patternOutNeighborList;
+    final private List<List<Node>> targetInNeighborList;
+    final private List<List<Node>> targetOutNeighborList;
     final private Map<Node,Integer> nodeNeighborListMap;
     final private int lo;
     final private int hi;
@@ -21,9 +22,8 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
 
     SubgraphProcessor(List<List<Node>> candidateList,
                       Map<Node, Integer> candidateNode2Index,
-                      int[] candidateListSize,
-                      List<List<Node>> queryNeighborList,
-                      List<List<Node>> nodeNeighborList,
+                      List<List<Node>> patternInNeighborList, List<List<Node>> patternOutNeighborList,
+                      List<List<Node>> targetInNeighborList,  List<List<Node>> targetOutNeighborList,
                       Map<Node,Integer> nodeNeighborListMap,
                       long splitSize,
                       ForkJoinPool threadPool) {
@@ -31,9 +31,10 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
         this.hi = candidateList.get(0).size();
         this.candidateList = candidateList;
         this.candidateNode2Index = candidateNode2Index;
-        this.candidateListSize = candidateListSize;
-        this.queryNeighborList = queryNeighborList;
-        this.nodeNeighborList = nodeNeighborList;
+        this.patternInNeighborList = patternInNeighborList;
+        this.patternOutNeighborList = patternOutNeighborList;
+        this.targetInNeighborList = targetInNeighborList;
+        this.targetOutNeighborList = targetOutNeighborList;
         this.nodeNeighborListMap = nodeNeighborListMap;
         this.threadPool = threadPool;
         this.matchedSubgraphs = new ArrayList<>();
@@ -42,32 +43,48 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
     }
 
     @Override
-    protected List<List<Node>> compute() {
+    protected List<List<Node>> compute()
+    {
         // Assign tasks to different threads
         List<SubgraphProcessor> tasks=new ArrayList<>();
 
-        if( hi - lo <= splitSize ) {
+        if( hi - lo <= splitSize )
+        {
             // A task is small enough for a single thread
-            matchedSubgraphs.addAll(backtracking(0, candidateList, candidateNode2Index, candidateListSize,
-                    queryNeighborList, nodeNeighborList, nodeNeighborListMap));
-        } else {
+            matchedSubgraphs.addAll(backtracking(0, candidateList, candidateNode2Index,
+                    patternInNeighborList, patternOutNeighborList,
+                    targetInNeighborList, targetOutNeighborList, nodeNeighborListMap));
+        }
+        else
+        {
             // A task is going to be split in half
             int mid = (lo + hi) >>> 1;
+
             List<List<Node>> leftCandidateList = copyNodeList(candidateList, lo, mid);
+
             List<List<Node>> rightCandidateList = copyNodeList(candidateList, mid, hi);
 
             SubgraphProcessor forkedTask1 = new SubgraphProcessor(leftCandidateList, candidateNode2Index,
-                    candidateListSize, queryNeighborList, nodeNeighborList, nodeNeighborListMap, splitSize, threadPool);
+                     patternInNeighborList, patternOutNeighborList,
+                    targetInNeighborList, targetOutNeighborList, nodeNeighborListMap,
+                    splitSize, threadPool);
+
             SubgraphProcessor forkedTask2 = new SubgraphProcessor(rightCandidateList, candidateNode2Index,
-                    candidateListSize, queryNeighborList, nodeNeighborList, nodeNeighborListMap, splitSize, threadPool);
+                     patternInNeighborList, patternOutNeighborList,
+                    targetInNeighborList, targetOutNeighborList, nodeNeighborListMap,
+                    splitSize, threadPool);
 
             // Don't use two fork() here, as that will make the current thread idle waiting for the forked threads until
             // they finish the task
             invokeAll(forkedTask1, forkedTask2);
+
             tasks.add(forkedTask1);
+
             tasks.add(forkedTask2);
+
             collectResultsFromTasks(matchedSubgraphs,tasks);
         }
+
         return matchedSubgraphs;
     }
 
@@ -77,26 +94,29 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
     private List<List<Node>> backtracking(int numLayer,
                                           List<List<Node>> candidateList,
                                           Map<Node, Integer> candidateNode2Index,
-                                          int[] candidateListSize,
-                                          List<List<Node>> queryNeighborList,
-                                          List<List<Node>> nodeNeighborList,
-                                          Map<Node, Integer> nodeNeighborListMap) {
+                                          List<List<Node>> patternInNeighborList, List<List<Node>> patternOutNeighborList,
+                                          List<List<Node>> targetInNeighborList, List<List<Node>> targetOutNeighborList,
+                                          Map<Node, Integer> nodeNeighborListMap)
+    {
+
         List<List<Node>> matchedSubgraphs=new ArrayList<>();
 
-        if (numLayer == queryNeighborList.size()) {
+        if (numLayer == candidateList.size()) {
             // A matching subgraph is found
             ArrayList<Node> subgraph = new ArrayList<>();
 
-            for (List<Node> aCandidateList : candidateList) {
+            for (List<Node> aCandidateList : candidateList)
                 subgraph.add(aCandidateList.get(0));
-            }
+
             matchedSubgraphs.add(subgraph);
+
             return matchedSubgraphs;
         }
 
         List<List<Node>> originalCandidateList = copyNodeList(candidateList,0,candidateList.get(0).size());
         // Retain the original copy of the candidateList for rolling back
-        for (int i=0; i < candidateList.get(numLayer).size(); i++) {
+        for (int i=0; i < candidateList.get(numLayer).size(); i++)
+        {
             ArrayList<Node> singleNode = new ArrayList<>();
 
             singleNode.add(candidateList.get(numLayer).get(i));
@@ -105,20 +125,23 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
             candidateList.get(numLayer).retainAll(singleNode);
 
             // Remove unique nodes in other rows
-            removeUniqueNodes(singleNode.get(0), candidateList, candidateListSize, numLayer, false);
+            removeUniqueNodes(singleNode.get(0), candidateList, numLayer);
 
             // Refine the candidate list
-            refineCandidate(candidateList,queryNeighborList,nodeNeighborList,candidateNode2Index,nodeNeighborListMap);
+            refineCandidate(candidateList,patternInNeighborList,patternOutNeighborList,targetInNeighborList,targetOutNeighborList,candidateNode2Index,nodeNeighborListMap);
 
-            if( isCorrect(candidateList) ) {
+            if( isCorrect(candidateList) )
+            {
                 // If the candidate list is valid, go to the next round recursively
                 List<List<Node>> pendingResult = backtracking(numLayer + 1, candidateList, candidateNode2Index,
-                        candidateListSize, queryNeighborList, nodeNeighborList, nodeNeighborListMap);
+                         patternInNeighborList,patternOutNeighborList,targetInNeighborList,targetOutNeighborList, nodeNeighborListMap);
+
                 if( ! pendingResult.isEmpty() ) matchedSubgraphs.addAll(pendingResult);
             }
 
             // Resume the candidate list and continue searching
             candidateList = copyNodeList(originalCandidateList, 0, originalCandidateList.get(0).size());
+
         }
         return matchedSubgraphs;
     }
@@ -126,82 +149,97 @@ public class SubgraphProcessor extends RecursiveTask<List<List<Node>>>{
     /**
      * Collect matching subgraphs from forked tasks
      */
-    private void collectResultsFromTasks(List<List<Node>> list, List<SubgraphProcessor> tasks) {
+    private void collectResultsFromTasks(List<List<Node>> list, List<SubgraphProcessor> tasks)
+    {
         for (SubgraphProcessor item:tasks) list.addAll(item.join());
     }
 
-    private List<List<Node>> copyNodeList(List<List<Node>> originalList,int start, int end) {
+    private List<List<Node>> copyNodeList(List<List<Node>> originalList,int start, int end)
+    {
         List<List<Node>> copyList = new ArrayList<>();
+
         ArrayList<Node> firstRow = new ArrayList<>();
-        for (int k = start; k < end; k++) {
+
+        for (int k = start; k < end; k++)
             firstRow.add(originalList.get(0).get(k));
-        }
+
         copyList.add(firstRow);
 
-        for (int i = 1; i < originalList.size(); i++) {
+        for (int i = 1; i < originalList.size(); i++)
+        {
             ArrayList<Node> temp = new ArrayList<>();
 
             temp.addAll(originalList.get(i));
+
             copyList.add(temp);
         }
+
         return copyList;
     }
 
     /**
-     * Given the three lists, refine the candidate list
+     * Given the candidate and neighbor lists, refine the candidate list
      */
     private void refineCandidate(List<List<Node>> candidateList,
-                                 List<List<Node>> queryNeighborList,
-                                 List<List<Node>> nodeNeighborList,
-                                 Map<Node, Integer> candidateNode2Index,
-                                 Map<Node, Integer> nodeNeighborListMap) {
+                                 List<List<Node>> patternInNeighborList,
+                                 List<List<Node>> patternOutNeighborList,
+                                 List<List<Node>> targetInNeighborList,
+                                 List<List<Node>> targetOutNeighborList,
+                                 Map<Node, Integer> candidateListMap,
+                                 Map<Node, Integer> nodeNeighborListMap)
+    {
+
         List<List<Node>> nodesToRemove = new ArrayList<>();
 
         // Create the list of node that should be removed
         candidateList.forEach( list -> nodesToRemove.add(new ArrayList<>()) );
 
-        IntStream.range(0, candidateList.size()).parallel().forEach(ii -> candidateList.get(ii).forEach(node -> {
-            boolean refinable = queryNeighborList.get(ii).parallelStream().allMatch(qnode ->
-                    candidateList.get(candidateNode2Index.get(qnode)).parallelStream().anyMatch(subnode ->
-                            nodeNeighborList.get(nodeNeighborListMap.get(node)).contains(subnode)));
+        IntStream.range(0,candidateList.size()).parallel().forEach(ii -> candidateList.get(ii).forEach(node ->
+        {
 
-            if ( ! refinable ) nodesToRemove.get(ii).add(node);
+            boolean inRefinable = patternInNeighborList.get(ii).parallelStream().allMatch(qnode ->
+                    candidateList.get(candidateListMap.get(qnode)).parallelStream().anyMatch(subnode ->
+                            targetInNeighborList.get(nodeNeighborListMap.get(node)).contains(subnode)));
+
+            boolean outRefinable = patternOutNeighborList.get(ii).parallelStream().allMatch(qnode ->
+                    candidateList.get(candidateListMap.get(qnode)).parallelStream().anyMatch(subnode ->
+                            targetOutNeighborList.get(nodeNeighborListMap.get(node)).contains(subnode)));
+
+            if (!(inRefinable && outRefinable))
+                nodesToRemove.get(ii).add(node);
+
         }));
 
         //Now remove the nodes from the candidate list
-        for (int i = 0; i < candidateList.size(); i++) {
+
+        for (int i=0;i<candidateList.size();i++)
             candidateList.get(i).removeAll(nodesToRemove.get(i));
-        }
+
+
     }
 
     /**
      * Check if the current candidate list is correct. (i.e., is there any empty candidate list?)
      */
-    private boolean isCorrect(List<List<Node>> candidateList) {
-        for (List<Node> aCandidateList : candidateList) {
+    private boolean isCorrect(List<List<Node>> candidateList)
+    {
+        for (List<Node> aCandidateList : candidateList)
             if (aCandidateList.isEmpty()) return false;
-        }
+
         return true;
     }
 
+    /**
+     * Remove redundant apprearance of the unique node in the candidate list
+     */
+
     private void removeUniqueNodes(Node unique,
                                    List<List<Node>> candidateList,
-                                   int[] candidateListSize,
-                                   int layer,
-                                   boolean TrimBranch) {
-        if( ! TrimBranch ) {
-            for (int i = layer+1; i < candidateList.size(); i++) {
-                if ( candidateList.get(i).contains(unique) ) candidateList.get(i).remove(unique);
-            }
-        } else {
-            // for trimming, pick nodes that have the same candidate list size as the node in the current layer
-            int currentLayer = layer - 1;
-            for (int i = layer; i < candidateList.size(); i++) {
-                if (candidateListSize[i] == candidateListSize[currentLayer]) {
-                    if ( candidateList.get(i).contains(unique) )
-                        candidateList.get(i).remove(unique);
-                } else break; // the main candidate list is sorted, so we break here when different size is found
-            }
-        }
+                                   int layer)
+    {
+
+        for (int i = layer+1; i < candidateList.size(); i++)
+            if ( candidateList.get(i).contains(unique) ) candidateList.get(i).remove(unique);
+
     }
 }


### PR DESCRIPTION
Now it supports directed graph. Initial candidate is picked when `targetIndegree>=patternIndegree && targetOutdegree >= patternOutdegree`.  Neighbors of pattern nodes and target nodes are separated into two groups: incoming neighbors and outgoing neighbors. The algorithm will be executed for both incoming and outgoing neighbors so it can differentiate edges with directions.

 Multi-threading performance is improved when the minimum-sized element in the candidate list is smaller than the optimal number of tasks (2*numOfThreads in this program). For example:

 
![untitled](https://cloud.githubusercontent.com/assets/26826972/26674411/057265ae-4686-11e7-998f-880f6d5346c7.png)

If we use this graph as the pattern and target graph at the same time, the candidate list of Vertex 5 has only one element: itself. Initially, the candidate list `List<List<Node>> candidateList`  is sorted by the size of each row (`candidateList.size()`). Tasks are split out of the elements of the first row `candidateList.get(0)`, which is also the number of iterations in the first loop of the backtracking process. In this case, `candidateList.get(0).size()=1`, so there will be no task split. The multi-threading merely depends on stealing behavior in the ForkJoinPool. Performance is poor.

Now, after sorting the candidate list ascendingly, the row with the smallest size yet equal to or greater than the number of threads will be picked and swap with the first row. For example, we have 4 threads and the optimal number of tasks is 8. The initial sizes of elements in `candidateList` is
1
8
8
.
.

The final candidate list after swapping becomes:
8
1
8
.
.

In this way, the first loop with 8 iterations can be split to 8 threads for maximum concurrency.  There is obvious performance improvement. 

